### PR TITLE
Implement InputProfile::from_rgb_space, using colorimetry's color spaces.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "android-tzdata"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -119,6 +125,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3995eaeebcdf32f91f980d360f78732ddc061097ab4e39991ae7a6ace9194677"
 
 [[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
 name = "cc"
 version = "1.2.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -193,6 +205,7 @@ name = "cmx"
 version = "0.0.2"
 dependencies = [
  "anyhow",
+ "approx",
  "chrono",
  "clap",
  "colorimetry",
@@ -204,6 +217,7 @@ dependencies = [
  "isocountry",
  "isolang",
  "md5",
+ "nalgebra",
  "num",
  "num-derive",
  "num-traits",
@@ -211,7 +225,7 @@ dependencies = [
  "serde",
  "serde_arrays",
  "serde_json",
- "strum 0.25.0",
+ "strum",
  "thiserror 2.0.14",
  "toml",
  "zerocopy",
@@ -226,16 +240,14 @@ checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 [[package]]
 name = "colorimetry"
 version = "0.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee632b003ce206406aca7f889b565e39965aa4841fe3940cec9c771a27fbacdb"
 dependencies = [
  "approx",
+ "geo",
  "js-sys",
  "libm",
  "nalgebra",
  "num-traits",
- "strum 0.26.3",
- "strum_macros 0.26.4",
+ "strum",
  "thiserror 1.0.69",
  "wasm-bindgen",
 ]
@@ -254,6 +266,31 @@ checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crunchy"
@@ -359,16 +396,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "earcutr"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79127ed59a85d7687c409e9978547cffb7dc79675355ed22da6b66fd5f6ead01"
+dependencies = [
+ "itertools",
+ "num-traits",
+]
+
+[[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
+name = "float_next_after"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bf7cc16383c4b8d58b9905a8509f02926ce3058053c056376248d958c9df1e8"
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "generic-array"
@@ -378,6 +443,46 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+]
+
+[[package]]
+name = "geo"
+version = "0.29.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34f0e6e028c581e82e6822a68869514e94c25e7f8ea669a2d8595bdf7461ccc5"
+dependencies = [
+ "earcutr",
+ "float_next_after",
+ "geo-types",
+ "geographiclib-rs",
+ "i_overlay",
+ "log",
+ "num-traits",
+ "robust",
+ "rstar",
+ "spade",
+]
+
+[[package]]
+name = "geo-types"
+version = "0.7.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75a4dcd69d35b2c87a7c83bce9af69fd65c9d68d3833a0ded568983928f3fc99"
+dependencies = [
+ "approx",
+ "num-traits",
+ "rayon",
+ "rstar",
+ "serde",
+]
+
+[[package]]
+name = "geographiclib-rs"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f611040a2bb37eaa29a78a128d1e92a378a03e0b6e66ae27398d42b1ba9a7841"
+dependencies = [
+ "libm",
 ]
 
 [[package]]
@@ -414,10 +519,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "hash32"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47d60b12902ba28e2730cd37e95b8c9223af2808df9e902d4df49588d1470606"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash",
+]
+
+[[package]]
+name = "heapless"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bfb9eb618601c89945a70e254898da93b13be0388091d42117462b265bb3fad"
+dependencies = [
+ "hash32",
+ "stable_deref_trait",
+]
 
 [[package]]
 name = "heck"
@@ -436,6 +565,50 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "i_float"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "775f9961a8d2f879725da8aff789bb20a3ddf297473e0c90af75e69313919490"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "i_key_sort"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "347c253b4748a1a28baf94c9ce133b6b166f08573157e05afe718812bc599fcd"
+
+[[package]]
+name = "i_overlay"
+version = "1.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01882ce5ed786bf6e8f5167f171a4026cd129ce17d9ff5cbf1e6749b98628ece"
+dependencies = [
+ "i_float",
+ "i_key_sort",
+ "i_shape",
+ "i_tree",
+ "rayon",
+]
+
+[[package]]
+name = "i_shape"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27dbe9e5238d6b9c694c08415bf00fb370b089949bd818ab01f41f8927b8774c"
+dependencies = [
+ "i_float",
+ "serde",
+]
+
+[[package]]
+name = "i_tree"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "155181bc97d770181cf9477da51218a19ee92a8e5be642e796661aee2b601139"
 
 [[package]]
 name = "iana-time-zone"
@@ -502,6 +675,15 @@ checksum = "fe50d48c77760c55188549098b9a7f6e37ae980c586a24693d6b01c3b2010c3c"
 dependencies = [
  "phf",
  "serde",
+]
+
+[[package]]
+name = "itertools"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
+dependencies = [
+ "either",
 ]
 
 [[package]]
@@ -684,6 +866,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -791,6 +974,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
 
 [[package]]
+name = "rayon"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "regex"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -818,6 +1021,23 @@ name = "regex-syntax"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
+
+[[package]]
+name = "robust"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e27ee8bb91ca0adcf0ecb116293afa12d393f9c2b9b9cd54d33e8078fe19839"
+
+[[package]]
+name = "rstar"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "421400d13ccfd26dfa5858199c30a5d76f9c54e0dba7575273025b43c5175dbb"
+dependencies = [
+ "heapless",
+ "num-traits",
+ "smallvec",
+]
 
 [[package]]
 name = "rustversion"
@@ -927,6 +1147,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
 
 [[package]]
+name = "smallvec"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "spade"
+version = "2.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb313e1c8afee5b5647e00ee0fe6855e3d529eb863a0fdae1d60006c4d1e9990"
+dependencies = [
+ "hashbrown",
+ "num-traits",
+ "robust",
+ "smallvec",
+]
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -938,14 +1182,8 @@ version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290d54ea6f91c969195bdbcd7442c8c2a2ba87da8bf60a7ee86a235d4bc1e125"
 dependencies = [
- "strum_macros 0.25.3",
+ "strum_macros",
 ]
-
-[[package]]
-name = "strum"
-version = "0.26.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
 
 [[package]]
 name = "strum_macros"
@@ -954,19 +1192,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23dc1fa9ac9c169a78ba62f0b841814b7abae11bdd047b9c58f893439e309ea0"
 dependencies = [
  "heck 0.4.1",
- "proc-macro2",
- "quote",
- "rustversion",
- "syn",
-]
-
-[[package]]
-name = "strum_macros"
-version = "0.26.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
-dependencies = [
- "heck 0.5.0",
  "proc-macro2",
  "quote",
  "rustversion",
@@ -1312,7 +1537,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
- "strum 0.25.0",
+ "strum",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,28 +18,30 @@ members = [
 v5 = []
 
 [dependencies]
+anyhow = "1.0.99"
+approx = "0.5.1"
 chrono = { version = "0.4.19", features = ["serde"] }
+clap = { version = "4.3", features = ["derive"] }
+colorimetry = {path = "../colorimetry", version = "0.0.7"}
+delegate = "0.13.4"
+half = { version = "2.6", features = ["serde"] }
+hex = "0.4.3"
+indexmap = { version = "2.10.0", features = ["serde"] }
+isocountry = "0.3.2"
+isolang = { version = "2.0", features = ["serde"] }
+md5 = "0.8.0"
+nalgebra = "0.33.2"
 num = "0.4.0"
 num-derive = "0.4"
 num-traits = "0.2.14"
-half = { version = "2.6", features = ["serde"] }
+paste = "1.0.15"
 serde = { version = "1.0.125", features = ["derive"] }
 serde_arrays = "0.2"
 serde_json = "1.0.64"
-isolang = { version = "2.0", features = ["serde"] }
-isocountry = "0.3.2"
-indexmap = { version = "2.10.0", features = ["serde"] }
-thiserror = "2.0.12"
-zerocopy = { version = "0.8.26", features = ["derive", "alloc"] }
-colorimetry = "0.0.7"
-delegate = "0.13.4"
-md5 = "0.8.0"
-paste = "1.0.15"
 strum = {version = "0.25", features = ["derive"]}  # for enum iteration and derive macros
-hex = "0.4.3"
+thiserror = "2.0.12"
 toml = "0.9.5"
-clap = { version = "4.3", features = ["derive"] }
-anyhow = "1.0.99"
+zerocopy = { version = "0.8.26", features = ["derive", "alloc"] }
 
 [[bin]]
 name = "cmx"

--- a/src/header.rs
+++ b/src/header.rs
@@ -109,7 +109,20 @@ impl RawProfile {
     /// interpret them correctly.  However, such a use is discouraged, as the ICC's intention is to
     /// improve color reproduction quality between devices and media, and not to create
     /// vendor-specific profiles.
+    /// # Example:
+    /// ```rust
+    /// use cmx::profile::RawProfile;
+    /// let profile = RawProfile::read("tests/profiles/Display P3.icc").unwrap();
+    /// let cmm = profile.cmm().unwrap();
+    /// assert_eq!(cmm, cmx::signatures::Cmm::Apple);
+    /// ```
     ///
+    /// ```rust
+    /// use cmx::profile::RawProfile;
+    /// let profile = RawProfile::read("tests/profiles/Display P3_cmx.icc").unwrap();
+    /// let cmm = profile.cmm().unwrap();
+    /// assert_eq!(cmm, cmx::signatures::Cmm::Apple);
+    /// ```
     pub fn cmm(&self) -> Option<Cmm> {
         let header = self.header();
         let tag = Signature(header.cmm.get());
@@ -577,7 +590,7 @@ impl RawProfile {
         let header = self.header();
         let m = header.manufacturer.get();
         let sig = Signature(m);
-        if is_printable_ascii_bytes(sig.to_string().as_bytes()) {
+        if m>0 && is_printable_ascii_bytes(sig.to_string().as_bytes()) {
             Some(sig)
         } else {
             None

--- a/src/profile/input_profile.rs
+++ b/src/profile/input_profile.rs
@@ -3,7 +3,7 @@
 
 use serde::Serialize;
 
-use crate::profile::Profile;
+use crate::{profile::Profile, tag::{bradford::Bradford, tags::*}};
 
 use super::RawProfile;
 
@@ -93,6 +93,73 @@ impl InputProfile {
         )
     }
 
+    /// Creates an input profile from a Colorimetry::RgbSpace.
+    /// 
+    /// This type of profile is typically used to embed in image files,
+    /// such as a PNG.
+    /// 
+    /// # Example
+    /// See `colorimetry-plot::examples::display_p3_gamut.rs` how this is used to show a full
+    /// DisplayP3 gamut in a CIE 1931 chromaticity diagram, if viewed on a high gamut display, using
+    /// a modern Web Browser with support of managed color workflows.
+    pub fn from_rgb_space(rgb_space: colorimetry::rgb::RgbSpace) -> InputProfile {
+        let input_profile = Self::new();
+        let pcs_illuminant = input_profile.pcs_illuminant(); // always D50
+        let obs = colorimetry::observer::Observer::Cie1931;
+        let pcs_illuminant_xyz = colorimetry::xyz::XYZ::new(pcs_illuminant, obs);
+        let media_white_xyz = rgb_space.white_point(obs).set_illuminance(1.0).values();
+        let m_rgb = obs.calc_rgb2xyz_matrix_with_alt_white(rgb_space, Some(pcs_illuminant_xyz));
+        let r_xyz = m_rgb.column(0);
+        let g_xyz = m_rgb.column(1);
+        let b_xyz = m_rgb.column(2);
+        let bradford = Bradford::new(media_white_xyz, pcs_illuminant).as_matrix();
+
+        input_profile
+            .with_tag(ProfileDescriptionTag)
+                .as_text_description(|text| {
+                    text.set_ascii("CMX_P3");
+                })
+            .with_tag(CopyrightTag)
+                .as_text(|text| {
+                    text.set_text("CC0");
+                })
+            .with_tag(MediaWhitePointTag)
+                .as_xyz_array(|xyz| {
+                    xyz.set(media_white_xyz);
+                })
+            .with_tag(RedMatrixColumnTag)
+                .as_xyz_array(|xyz| {
+                    xyz.set(r_xyz.as_slice().try_into().unwrap());
+                })
+            .with_tag(GreenMatrixColumnTag)
+                .as_xyz_array(|xyz| {
+                    xyz.set(g_xyz.as_slice().try_into().unwrap());
+                })
+            .with_tag(BlueMatrixColumnTag)
+                .as_xyz_array(|xyz| {
+                    xyz.set(b_xyz.as_slice().try_into().unwrap());
+                })
+            .with_tag(ChromaticAdaptationTag)
+                .as_sf15_fixed_16_array(|array| {
+                    let bradford_array: [f64; 9] = bradford.as_slice().try_into().unwrap();
+                    array.set(bradford_array);
+                })
+            .with_tag(RedTRCTag)
+                .as_parametric_curve(|para| {
+                    para.set_parameters([2.4, 0.94786, 0.05214, 0.07739, 0.04045]);
+                })
+            .with_tag(BlueTRCTag)
+                .as_parametric_curve(|para| {
+                    para.set_parameters([2.4, 0.94786, 0.05214, 0.07739, 0.04045]);
+                })
+            .with_tag(GreenTRCTag)
+                .as_parametric_curve(|para| {
+                    para.set_parameters([2.4, 0.94786, 0.05214, 0.07739, 0.04045]);
+                })
+            .with_profile_id()
+        
+    }
+
     #[allow(unused)]
     /// Creates a new Three-component matrix-based ("RGB") InputProfile
     /// using one of RGB color spaces as defined in the Rust `Colorimetry` library.
@@ -118,5 +185,19 @@ impl TryFrom<Profile> for InputProfile {
         } else {
             Err(Self::Error::IsNotA("Input Profile"))
         }
+    }
+}
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_input_profile_from_rgb_space() {
+        let input_profile = InputProfile::from_rgb_space(colorimetry::rgb::RgbSpace::DisplayP3);
+        let bytes = input_profile.to_bytes().unwrap();
+        let input_profile_2 = InputProfile::try_from(Profile::from_bytes(&bytes).unwrap()).unwrap();
+        println!("{}", input_profile_2);
     }
 }

--- a/src/tag.rs
+++ b/src/tag.rs
@@ -2,6 +2,8 @@
 // Copyright (c) 2021-2025, Harbers Bik LLC
 
 pub mod tagdata;
+
+pub mod bradford;
 /*
 mod parse;
 pub use parse::{UnambiguousTag, IsCurveTag, IsParametricCurveTag, IsTextDescriptionTag, IsMultiLocalizedUnicodeTag, IsLut8DataTag, IsLut16DataTag, IsLutAtoBDataTag, IsLutBtoADataTag};

--- a/src/tag/bradford.rs
+++ b/src/tag/bradford.rs
@@ -1,0 +1,97 @@
+
+use nalgebra::Matrix3;
+
+use crate::S15Fixed16;
+
+pub struct Bradford {
+    m_adapt: Matrix3<f64>,
+}
+
+impl Bradford {
+    const BRADFORD_ADAPT: Matrix3<f64> = Matrix3::new(
+        0.8951, 0.2664, -0.1614,
+        -0.7502, 1.7135, 0.0367,
+        0.0389, -0.0685, 1.0296,
+    );
+
+    const BRADFORD_ADAPT_INV: Matrix3<f64> = Matrix3::new(
+        0.9869929, -0.1470543, 0.1599627,
+        0.4323053, 0.5183603, 0.0492912,
+        -0.0085287, 0.0400428, 0.9684867,
+    );
+
+    pub fn new(source_white: [f64; 3], target_white: [f64; 3]) -> Self {
+        let source_cone_response = Self::BRADFORD_ADAPT * nalgebra::Vector3::from_column_slice(&source_white);
+        let target_cone_response = Self::BRADFORD_ADAPT * nalgebra::Vector3::from_column_slice(&target_white);
+
+        let scale = Matrix3::new(
+            target_cone_response[0] / source_cone_response[0], 0.0, 0.0,
+            0.0, target_cone_response[1] / source_cone_response[1], 0.0,
+            0.0, 0.0, target_cone_response[2] / source_cone_response[2],
+        );
+
+        let m_adapt = Self::BRADFORD_ADAPT_INV * scale * Self::BRADFORD_ADAPT;
+
+        Bradford { m_adapt }
+    }
+
+    pub fn adapt(&self, color: [f64; 3]) -> [f64; 3] {
+        let adapted = self.m_adapt * nalgebra::Vector3::from_column_slice(&color);
+        [adapted[0], adapted[1], adapted[2]]
+    }
+
+    pub fn as_matrix(&self) -> Matrix3<f64> {
+        self.m_adapt
+    }
+
+    pub fn as_tag_data(&self) -> [S15Fixed16; 9] {
+        let mut data = [S15Fixed16::from(0.0); 9];
+        for i in 0..3 {
+            for j in 0..3 {
+                data[i * 3 + j] = S15Fixed16::from(self.m_adapt[(i, j)]);
+            }
+        }
+        data
+    }
+}
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_bradford_adaptation() {
+        let source_white = [0.95047, 1.00000, 1.08883]; // D65
+        let target_white = [0.96422, 1.00000, 0.82521]; // D50
+
+        let bradford = Bradford::new(source_white, target_white);
+
+        let color = source_white;
+        let adapted_color = bradford.adapt(color);
+
+        // Expected values can be calculated using a reliable color science library or tool
+        let expected_color = target_white;
+        approx::assert_abs_diff_eq!(adapted_color.as_slice(), expected_color.as_slice(), epsilon = 0.0001);
+    }
+
+    #[test]
+    fn test_bradford_tag_data() {
+        let d65 = [0.95047, 1.00000, 1.08883]; // D65
+        let d50 = [0.96422, 1.00000, 0.82521]; // D50
+
+        // values from Apple's DisplayP3 ICC profile
+        // matrix = [[1.047882, 0.022919, -0.050201], [0.029587, 0.990479, -0.017059], [-0.009232, 0.015076, 0.751678]]
+
+        let want = Matrix3::new(
+            1.0478112, 0.0228866, -0.0501270,
+            0.0295424, 0.9904844, -0.0170491,
+            -0.0092345, 0.0150436,0.7521316,
+        );
+
+        let bradford = Bradford::new(d65, d50);
+        let got = bradford.as_matrix();
+        approx::assert_abs_diff_eq!(got, want, epsilon = 0.0001);
+    }
+}
+


### PR DESCRIPTION
Create InputProfiles to be embedded in images using `Colorimetry` color spaces.

This is to be used, for example, in the DisplayP3 example plot, in the `colorimetry-plot` crate. Without an embedded color profile, the RGB values are interpreted as sRGB, whereas they are actually Display P3 RGB color values.