### PR TITLE
Input validation, documentation, tests, and v0.1.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,13 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 * `Error::ProfileTooLarge(usize)` — new error variant when a serialised profile
   exceeds the ICC 4 GiB size limit.
 
+## [0.0.6] - 2026-04-20
+
+### Changed
+
+* Bumped `colorimetry` dependency from `0.0.8` to `0.0.9`; adapted call sites to
+  the renamed `XYZ::values()` → `XYZ::to_array()` method.
+
 ## [0.0.5] - 2025-09-17
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+## [0.0.7] - 2026-04-23
+
 ### Fixed
 
 * **LUT8 parser** — replaced silent integer overflow in CLUT size calculation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
-## [0.0.7] - 2026-04-23
+## [0.1.0] - 2026-04-24
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,51 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 * **Fixed**: for any bug fixes.
 * **Security**: in case of vulnerabilities.
 
+## [Unreleased]
+
+### Fixed
+
+* **LUT8 parser** — replaced silent integer overflow in CLUT size calculation
+  (`g.pow(n) * m`) with `checked_pow` / `checked_mul`; added an `assert!` bounds
+  check before all slice indexing to prevent out-of-bounds panics on malformed
+  tag data.
+* **LUT8 / LUT16 parsers** — replaced `.unwrap()` on the `zerocopy` header
+  overlay with `.expect(…)` carrying a descriptive message.
+* **`RawProfile::creation_date()`** — changed return type from
+  `DateTime<Utc>` to `Result<DateTime<Utc>, Error>`; invalid header date fields
+  (e.g. month 13, hour 25) now return `Error::InvalidDate` instead of panicking.
+  All callers updated; `parsed_header` renders `<invalid: …>` for display.
+* **`RawProfile::with_now_as_creation_date()`** — replaced `.unwrap()` on
+  `with_nanosecond(0)` with `.expect(…)` and a comment explaining the invariant.
+* **Curve tag parser** — added a `debug_assert` to detect odd-length payloads
+  (which `chunks_exact(2)` would silently drop); clarified the safety invariant
+  for the `try_into().unwrap()` that follows.
+* **`ParametricCurveData::set_parameters_slice()`** — changed return type to
+  `Result<(), Error>`; invalid ICC parameter counts (anything other than 1, 3, 4,
+  5, or 7) now return `Error::UnsupportedParameterCount` instead of panicking.
+  `WriteLayoutHeader::new` updated accordingly; three internal call sites in
+  `DisplayProfile` updated to use `.expect(…)`.
+* **`RawProfile::into_bytes()`** — replaced silent `buf.len() as u32` cast with
+  `u32::try_from(buf.len())`, returning `Error::ProfileTooLarge` if the profile
+  exceeds the ICC-specified 4 GiB limit.
+* **MultiLocalizedUnicode parser** — added bounds checks on the records-table
+  slice and on each record's offset + length before indexing; replaced `.unwrap()`
+  on `String::from_utf16` with a lossy fallback; added a `debug_assert` to flag
+  non-even UTF-16 byte counts.
+* **`RawProfile::from_bytes()` tag-sharing detection** — `share_tags` now also
+  validates that duplicate tag-table offsets carry identical sizes; two tags at the
+  same offset but with different sizes are treated as a corrupt profile and an
+  `InvalidData` error is returned.
+
+### Added
+
+* `Error::InvalidDate(String)` — new error variant for out-of-range date/time
+  fields in ICC profile headers.
+* `Error::UnsupportedParameterCount(usize)` — new error variant for parametric
+  curve parameter counts that are not defined by the ICC specification.
+* `Error::ProfileTooLarge(usize)` — new error variant when a serialised profile
+  exceeds the ICC 4 GiB size limit.
+
 ## [0.0.5] - 2025-09-17
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,168 @@
+# CMX — Rust ICC Color Profile Library
+
+## What This Is
+
+CMX is a Rust library for working with ICC color profiles (versions 2.0–5.0). It supports:
+- **Parsing** binary ICC profiles from files or byte slices
+- **Constructing** profiles from scratch via a builder-style API
+- **Modifying** existing profiles programmatically
+- **Converting** profiles to human-readable TOML format
+- A **CLI tool** (`cmx`) to convert ICC profiles to TOML
+
+It integrates with the [`colorimetry`](https://crates.io/crates/colorimetry) crate for color space operations and uses `zerocopy` for memory-safe binary data handling.
+
+---
+
+## Build, Test, and Run
+
+```bash
+# Build
+cargo build
+cargo build --release
+
+# Test (all integration tests live in tests/)
+cargo test
+cargo test --test roundtrip          # round-trip serialization
+cargo test --test displayP3          # Display P3 profile construction
+
+# CLI tool
+cargo install --path .               # installs `cmx` binary
+cmx profile.icc                      # print TOML to stdout
+cmx profile.icc -o profile.toml      # write TOML to file
+
+# Examples
+cargo run --example primaries
+cargo run --example set_relcolorimetric_intent -- path/to/profile.icc
+
+# Docs
+cargo doc --open
+```
+
+---
+
+## Project Layout
+
+```
+src/
+  lib.rs                    # Library root, utility functions
+  error.rs                  # Error types
+  bin/cmx.rs                # CLI entry point
+  header.rs / header/       # ICC header (128-byte structure)
+  profile.rs / profile/     # Profile enum + per-device-class types
+  signatures.rs / signatures/ # ICC 4-byte signature enums
+  tag.rs / tag/             # Tag definitions, parsed tags
+  tag/tagdata/              # Individual tag data types
+tests/                      # Integration tests + test .icc files
+examples/                   # Runnable example programs
+xtask/                      # Code generation / maintenance utilities
+```
+
+---
+
+## Architecture
+
+### Profile Type System
+
+The `Profile` enum wraps eight device-class-specific structs, all backed by `RawProfile`:
+
+| Struct | Device class |
+|---|---|
+| `DisplayProfile` | Monitors, projectors |
+| `InputProfile` | Cameras, scanners |
+| `OutputProfile` | Printers |
+| `DeviceLinkProfile` | Device-to-device transforms |
+| `AbstractProfile` | Abstract color transforms |
+| `ColorSpaceProfile` | Color space definitions |
+| `NamedColorProfile` | Named color palettes |
+| `SpectralProfile` | Spectral data (future) |
+
+Each wrapper enforces ICC spec constraints for that class. `RawProfile` holds the actual binary data (bytes + `IndexMap` of tag records). `HasRawProfile` is the delegation trait.
+
+### Builder / Tag Setter Pattern
+
+Tags are set via a consuming builder chain:
+
+```rust
+let profile = DisplayProfile::new()
+    .with_tag(ProfileDescriptionTag)
+        .as_text_description(|t| t.set_ascii("My Profile"))
+    .with_tag(MediaWhitePointTag)
+        .as_xyz_array(|xyz| xyz.set([0.9505, 1.0, 1.0891]))
+    .with_profile_id();  // computes MD5 checksum in place
+```
+
+`TagSetter<P, S>` is the intermediate builder type. It uses generic marker types and capability traits to enforce at compile time which tag data types are valid for a given tag signature.
+
+### Tag Data Types
+
+`TagData` is the core enum covering all supported ICC tag payload types:
+`CurveData`, `ParametricCurveData`, `XYZArrayData`, `TextData`, `TextDescriptionData`,
+`MultiLocalizedUnicodeData`, `S15Fixed16ArrayData`, `ChromaticityData`, `MeasurementData`,
+`Lut8Data`, `Lut16Data`, `SignatureData`, `RawData`, and more.
+
+Unknown/vendor tags are preserved via `RawData` — round-trips are lossless.
+
+### Key Types
+
+- `S15Fixed16` — 15.16 fixed-point number (used for matrices and XYZ values)
+- `Signature` — generic 4-byte ICC identifier parser
+- `TagSignature` — 70+ known ICC tag type identifiers + `Unknown(u32)`
+- `ColorSpace`, `DeviceClass`, `Pcs`, `Platform`, `Technology` — signature enums
+- `RenderingIntent` — Perceptual, RelativeColorimetric, Saturation, AbsoluteColorimetric
+- `Illuminant` — D50, D65, D93, F2, A, E, Daylight, BlackBody, etc.
+
+### Binary Safety
+
+Uses `zerocopy` for zero-copy overlay of the 128-byte ICC header — no unsafe code required. `IndexMap` preserves tag insertion order from the source profile, which is critical for deterministic round-trips and offset recalculation.
+
+---
+
+## Dependencies (Notable)
+
+| Crate | Purpose |
+|---|---|
+| `colorimetry = "0.0.9"` | Color space definitions (RgbSpace, etc.) |
+| `zerocopy = "0.8"` | Safe binary overlay for ICC header |
+| `nalgebra = "0.33"` | Matrix math |
+| `chrono = "0.4"` | DateTime in profile headers |
+| `indexmap = "2"` | Order-preserving tag map |
+| `serde` / `toml` | TOML serialization |
+| `md5 = "0.8"` | Profile ID checksum |
+| `thiserror = "2"` | Error types |
+| `clap = "4"` | CLI arg parsing |
+| `strum = "0.25"` | Enum utilities |
+| `delegate = "0.13"` | Method delegation to RawProfile |
+
+---
+
+## Key Conventions
+
+- **Lossless round-trips**: Unknown tags are stored as `RawData` and written back verbatim. Any test that reads a real ICC file and re-serializes it must produce byte-identical output.
+- **Profile ID**: Call `.with_profile_id()` at the end of profile construction to compute and embed the MD5 checksum (fields 84–99 of the header, zeroed during computation per the ICC spec).
+- **Tag data sharing**: Multiple tag signatures can reference the same offset in the file. The library detects and preserves this optimization.
+- **Consuming builder**: `with_tag(...)` and `as_*` methods consume `self` and return a new value. Do not attempt to reuse intermediate `TagSetter` values.
+- **Feature flags**: ICC v5 support is gated behind a `v5` feature flag.
+
+---
+
+## Common Entry Points
+
+```rust
+// Read an existing profile
+let profile = Profile::read("path/to/profile.icc")?;
+
+// Build a standard display profile
+let p3 = DisplayProfile::cmx_display_p3(RenderingIntent::RelativeColorimetric);
+
+// Serialize to bytes (for writing or embedding)
+let bytes = profile.into_bytes()?;
+
+// Write to disk
+profile.write("output.icc")?;
+```
+
+---
+
+## Testing Notes
+
+Integration tests in `tests/` use real `.icc` files stored under `tests/profiles/`. When adding new tag parsers or modifying serialization, always run the round-trip tests to confirm byte-identical output. The `displayP3` test compares a programmatically constructed profile against Apple's shipped Display P3 profile binary.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -234,36 +234,49 @@ Search the codebase for any hard-coded version strings in documentation and upda
 grep -rn "0\.0\.X" --include="*.rs" --include="*.toml" --include="*.md"
 ```
 
-### 5. Run the full test suite
+### 5. Run the full test suite and quality checks
 
 ```bash
 cargo test                    # unit + integration tests
 cargo test --doc              # doc-tests
-cargo clippy -- -D warnings   # no new lints
-cargo doc --no-deps           # docs must build cleanly
+cargo clippy -- -D warnings   # must produce zero warnings
+cargo doc --no-deps           # must produce zero warnings
 ```
 
-All tests must pass before tagging.
+All tests must pass and both `clippy` and `cargo doc` must be warning-free before tagging.
 
-### 6. Commit the release
+### 6. Regenerate README.md
 
-Stage only the version-bump files:
+The `README.md` is generated from the crate-level doc comment in `src/lib.rs` using
+[`cargo-rdme`](https://github.com/orium/cargo-rdme).  Run it after any change to `src/lib.rs`,
+and always as part of a release:
 
 ```bash
-git add Cargo.toml CHANGELOG.md
+cargo rdme
+```
+
+Review the diff (`git diff README.md`) to confirm the output looks correct, then stage the file.
+If `cargo-rdme` is not installed: `cargo install cargo-rdme`.
+
+### 7. Commit the release
+
+Stage only the version-bump and generated files:
+
+```bash
+git add Cargo.toml CHANGELOG.md README.md
 git commit -m "chore: release v0.0.X"
 ```
 
 Do **not** amend earlier commits or squash history — keep the release commit separate and minimal.
 
-### 7. Tag the release
+### 8. Tag the release
 
 ```bash
 git tag -a v0.0.X -m "Release v0.0.X"
 git push origin main --tags
 ```
 
-### 8. Publish to crates.io
+### 9. Publish to crates.io
 
 ```bash
 cargo publish

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -166,3 +166,107 @@ profile.write("output.icc")?;
 ## Testing Notes
 
 Integration tests in `tests/` use real `.icc` files stored under `tests/profiles/`. When adding new tag parsers or modifying serialization, always run the round-trip tests to confirm byte-identical output. The `displayP3` test compares a programmatically constructed profile against Apple's shipped Display P3 profile binary.
+
+---
+
+## Commit and PR Policy
+
+### Direct commits to `main`
+
+Permitted only for changes that carry no behavioral risk:
+
+- Typo or grammar fixes in documentation or comments
+- `CHANGELOG.md` updates (the release commit itself)
+- `Cargo.toml` version bump (the release commit itself)
+- CI / GitHub Actions configuration changes with no code impact
+- Dependency-only bumps that pass all tests and change no public API
+
+### Pull Requests (required)
+
+Everything else goes through a PR so that CI runs and a second pair of eyes can review before the change lands on `main`:
+
+- Any change to `src/` (new features, bug fixes, refactors, API changes)
+- New or modified integration tests in `tests/`
+- Changes to examples in `examples/`
+- Any change that touches public API surface (adding/removing/renaming types, methods, or error variants)
+
+Branch naming convention: `fix/<short-description>`, `feat/<short-description>`, `docs/<short-description>`.
+
+---
+
+## Release Process
+
+Follow these steps in order.  All commands run from the repository root on a clean `main` branch.
+
+### 1. Decide the new version number
+
+This crate uses [Semantic Versioning](https://semver.org/).  While the version is `0.0.x`
+(pre-1.0), any user-visible change — including new public API or bug fixes — warrants a
+patch increment.  Use a minor increment (`0.1.0`) when the public API is considered stable
+enough to declare a broader interface contract.
+
+| Change type | Version bump |
+|---|---|
+| Bug fixes, internal refactors, docs | patch (`0.0.x → 0.0.x+1`) |
+| New public API, new features | minor (`0.x.0 → 0.x+1.0`) |
+| Breaking API changes | major (`x.0.0 → x+1.0.0`) |
+
+### 2. Merge all pending PRs
+
+Ensure the `main` branch is up to date and all intended changes are merged.
+
+### 3. Update `CHANGELOG.md`
+
+- Rename the `## [Unreleased]` heading to `## [X.Y.Z] - YYYY-MM-DD` (today's date).
+- Add a fresh `## [Unreleased]` section above it (empty, ready for the next cycle).
+- Review the entries: make sure every user-visible change since the previous release is listed.
+  Compare against `git log vPREV..HEAD --oneline` to catch anything missing.
+
+### 4. Bump the version in `Cargo.toml`
+
+```bash
+# Edit the `version = "..."` field in [package]
+```
+
+Search the codebase for any hard-coded version strings in documentation and update them too:
+
+```bash
+grep -rn "0\.0\.X" --include="*.rs" --include="*.toml" --include="*.md"
+```
+
+### 5. Run the full test suite
+
+```bash
+cargo test                    # unit + integration tests
+cargo test --doc              # doc-tests
+cargo clippy -- -D warnings   # no new lints
+cargo doc --no-deps           # docs must build cleanly
+```
+
+All tests must pass before tagging.
+
+### 6. Commit the release
+
+Stage only the version-bump files:
+
+```bash
+git add Cargo.toml CHANGELOG.md
+git commit -m "chore: release v0.0.X"
+```
+
+Do **not** amend earlier commits or squash history — keep the release commit separate and minimal.
+
+### 7. Tag the release
+
+```bash
+git tag -a v0.0.X -m "Release v0.0.X"
+git push origin main --tags
+```
+
+### 8. Publish to crates.io
+
+```bash
+cargo publish
+```
+
+`cargo publish` performs a dry-run check internally; if it fails, fix the issue before pushing the tag.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -220,7 +220,7 @@ checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
 
 [[package]]
 name = "cmx"
-version = "0.0.7"
+version = "0.1.0"
 dependencies = [
  "anyhow",
  "approx",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -220,7 +220,7 @@ checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
 
 [[package]]
 name = "cmx"
-version = "0.0.5"
+version = "0.0.6"
 dependencies = [
  "anyhow",
  "approx",
@@ -257,9 +257,9 @@ checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "colorimetry"
-version = "0.0.8"
+version = "0.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f00a838cbc1a52e72755ea0a25ed422f8be600d959c070b40ef1348c9a8ea98f"
+checksum = "414bd7683a5ae3971e6d15dd3abbdf0d336c55276934ee862e83ad8de7517e52"
 dependencies = [
  "approx",
  "geo",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -220,7 +220,7 @@ checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
 
 [[package]]
 name = "cmx"
-version = "0.0.6"
+version = "0.0.7"
 dependencies = [
  "anyhow",
  "approx",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cmx"
-version = "0.0.7"
+version = "0.1.0"
 description = "Rust Spectral Color Management Library"
 authors = ["Gerard Harbers", "Harbers Bik LLC"]
 repository = "https://github.com/harbik/cmx"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cmx"
-version = "0.0.6"
+version = "0.0.7"
 description = "Rust Spectral Color Management Library"
 authors = ["Gerard Harbers", "Harbers Bik LLC"]
 repository = "https://github.com/harbik/cmx"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cmx"
-version = "0.0.5"
+version = "0.0.6"
 description = "Rust Spectral Color Management Library"
 authors = ["Gerard Harbers", "Harbers Bik LLC"]
 repository = "https://github.com/harbik/cmx"
@@ -22,7 +22,7 @@ anyhow = "1.0.99"
 approx = "0.5.1"
 chrono = { version = "0.4.19", features = ["serde"] }
 clap = { version = "4.3", features = ["derive"] }
-colorimetry = "0.0.8"
+colorimetry = "0.0.9"
 delegate = "0.13.4"
 # half = { version = "2.6", features = ["serde"] }
 hex = "0.4.3"

--- a/README.md
+++ b/README.md
@@ -1,23 +1,39 @@
 # CMX: Rust Spectral Color Management Library
 <!-- cargo-rdme start -->
 
-This crate provides utilities for working with ICC color profiles
-and integrates with the Colorimetry Library.
+`cmx` is a Rust library for reading, writing, and constructing [ICC color profiles][icc-spec]
+(versions 2.0–5.0).  ICC profiles describe how color values produced by a device (camera,
+display, printer) relate to a standard reference color space, making them essential for
+accurate color reproduction across devices and applications.
 
-### Use Cases
-<details><summary><strong>Parsing ICC profiles and conversion to TOML format for analysis</strong></summary>
-After installing the library, you can parse an ICC profile and convert it to a TOML format using the `cmx` command-line tool:
+[icc-spec]: https://www.color.org/specification/ICC.1-2022-05.pdf
 
-```bash
-cmx profile.icc -o profile.toml
+## Quick Start
+
+### Read a profile from disk
+
+```rust
+use cmx::profile::Profile;
+
+let profile = Profile::read("profile.icc")?;
+println!("Color space : {:?}", profile.data_color_space());
+println!("PCS         : {:?}", profile.pcs());
+println!("Version     : {:?}", profile.version()?);
 ```
 
-Each ICC profile tag is mapped to a key in the TOML file, with the
-corresponding values serialized as key-value pairs.
-All values are written as single-line entries to ensure the TOML output
-remains human-readable and easy to inspect.
+### Dump a profile as TOML
 
-Example of a parsed ICC profile in TOML format:
+The [`fmt::Display`](std::fmt::Display) implementation on every profile type serialises it
+to TOML — the same output produced by the `cmx` CLI tool:
+
+```rust
+use cmx::profile::Profile;
+
+let profile = Profile::read("profile.icc")?;
+println!("{profile}");
+```
+
+The output looks like:
 
 ```toml
 profile_size = 548
@@ -37,20 +53,8 @@ profile_id = "53410ea9facdd9fb57cc74868defc33f"
 [desc]
 ascii = "SMPTE RP 431-2-2007 DCI (P3)"
 
-[cprt]
-text = "Copyright Apple Inc., 2015"
-
 [wtpt]
 xyz = [0.894592, 1.0, 0.954422]
-
-[rXYZ]
-xyz = [0.48616, 0.226685, -0.000809]
-
-[gXYZ]
-xyz = [0.323853, 0.710327, 0.043228]
-
-[bXYZ]
-xyz = [0.15419, 0.062988, 0.782471]
 
 [rTRC]
 g = 2.60001
@@ -61,32 +65,19 @@ matrix = [
     [0.055573, 0.963989, -0.014343],
     [-0.004272, 0.005295, 0.862778]
 ]
+```
 
-[bTRC]
-g = 2.60001
+### Build a profile from scratch
 
-[gTRC]
-g = 2.60001
-
- ```
-</details>
-
-<details><summary><strong>Generate ICC profiles</strong></summary>
-
-You can also use the `cmx` library to create ICC profiles from scratch, or read existing
-profiles and change them, using Rust.
-
-The library provides a builder-style API for constructing, or read and change profiles,
-allowing you to set or change various tags and properties.
-
-Here is an example for creating a Display P3 ICC profile:
+The consuming builder API sets tags one by one and computes the profile ID at the end:
 
 ```rust
 use chrono::{DateTime, TimeZone};
 use cmx::tag::tags::*;
 use cmx::profile::DisplayProfile;
+
 let display_p3_example = DisplayProfile::new()
-    // set creation date, if omitted, the current date and time are used
+    // set creation date — current date/time is used if omitted
     .with_creation_date(chrono::Utc.with_ymd_and_hms(2025, 8, 28, 0, 0, 0).unwrap())
     .with_tag(ProfileDescriptionTag)
         .as_text_description(|text| {
@@ -132,72 +123,151 @@ let display_p3_example = DisplayProfile::new()
                 -0.009232, 0.015076,  0.751678
             ]);
         })
-    .with_profile_id() // calculate and add profile ID to the profile
-    ;
+    .with_profile_id(); // compute and embed the MD5 profile ID
 
-display_p3_example.write("tmp/display_p3_example.icc").unwrap();
-let display_p3_read_back = cmx::profile::Profile::read("tmp/display_p3_example.icc").unwrap();
-assert_eq!(
-    display_p3_read_back.profile_id_as_hex_string(),
-    "617028e1 e1014e15 91f178a9 fb8efc92"
-);
-assert_eq!(display_p3_read_back.profile_size(), 524);
+// Serialise to bytes without touching the filesystem
+let bytes = display_p3_example.to_bytes().unwrap();
+assert_eq!(bytes.len(), 524);
 ```
 
-Not all ICC tag types are supported yet, but please submit a pull request, or an issue, on our
-[GitHub CMX repo](https://github.com/harbik/cmx) if you want additional tag types to be supported.
+### Modify an existing profile
 
-However, you can use the `as_raw` method to set raw data for tags that are not yet supported.
+Read a profile, change a tag, and write it back:
 
-</details>
+```rust
+use cmx::profile::Profile;
+use cmx::tag::tags::CopyrightTag;
 
+Profile::read("input.icc")?
+    .with_tag(CopyrightTag)
+        .as_text(|t| t.set_text("Copyright 2025 Acme Corp."))
+    .write("output.icc")?;
+```
 
+## Modules
 
-### Installation
+| Module | Contents |
+|---|---|
+| [`profile`] | `Profile` enum and per-device-class types (`DisplayProfile`, `InputProfile`, …) |
+| [`tag`] | Tag signatures, tag data types, and the `TagSetter` builder |
+| [`header`] | ICC 128-byte header fields and accessors |
+| [`signatures`] | ICC 4-byte signature enums (`ColorSpace`, `DeviceClass`, `RenderingIntent`, …) |
+| [`error`] | [`Error`] type returned by public API functions |
 
-Install the `cmx` tool using Cargo:
+## ICC Profile Concepts
+
+An ICC profile is a binary file with three sections:
+
+1. **128-byte header** — fixed fields: device class, color space, PCS, version, creation date, etc.
+2. **Tag table** — a list of `(signature, offset, size)` entries pointing into the data block.
+3. **Tag data** — the actual payload for each tag (matrices, curves, look-up tables, text, …).
+
+### Device Classes
+
+The ICC specification defines eight device classes.  This crate provides a dedicated type for each:
+
+| Type | ICC class code | Typical use |
+|---|---|---|
+| [`profile::DisplayProfile`] | `mntr` | Monitors, projectors |
+| [`profile::InputProfile`] | `scnr` | Cameras, scanners |
+| [`profile::OutputProfile`] | `prtr` | Printers |
+| [`profile::DeviceLinkProfile`] | `link` | Direct device-to-device transforms |
+| [`profile::AbstractProfile`] | `abst` | Abstract color transforms |
+| [`profile::ColorSpaceProfile`] | `spac` | Color space definitions |
+| [`profile::NamedColorProfile`] | `nmcl` | Named color palettes |
+| [`profile::SpectralProfile`] | `cenc` | Spectral data (ICC v5) |
+
+All types wrap a [`profile::RawProfile`] which holds the raw binary data and
+preserves unknown tags verbatim, guaranteeing lossless round-trips.
+
+### Profile Connection Space (PCS)
+
+Profiles connect device-specific color values to a common reference color space called the
+**Profile Connection Space (PCS)**.  Two PCS values are defined by the ICC specification:
+
+- `XYZ` — CIE 1931 XYZ, used by most display and output profiles.
+- `Lab` — CIELAB (L\*a\*b\*), used by some output and abstract profiles.
+
+### Rendering Intents
+
+The rendering intent controls how out-of-gamut colors are handled during color conversion.
+Four intents are defined:
+
+| Intent | Typical use |
+|---|---|
+| Perceptual | Photographic images — compresses the gamut smoothly |
+| Relative Colorimetric | Graphics — clips and maps the source white point |
+| Saturation | Business graphics — maximises saturation |
+| Absolute Colorimetric | Proofing — preserves absolute colorimetric values |
+
+### Tags
+
+Tags are identified by a 4-byte signature (e.g. `rXYZ`, `rTRC`, `desc`).  Each tag carries a
+payload of a specific ICC type — an XYZ triplet, a tone-reproduction curve, a text string, etc.
+All well-known tag signatures are re-exported from [`tag::tags`].
+
+Tag types supported for reading and writing include:
+
+| ICC type | Rust type | Common tags |
+|---|---|---|
+| `XYZ` | `XYZArrayData` | `rXYZ`, `gXYZ`, `bXYZ`, `wtpt` |
+| `para` | `ParametricCurveData` | `rTRC`, `gTRC`, `bTRC` |
+| `curv` | `CurveData` | `rTRC`, `gTRC`, `bTRC` |
+| `mluc` | `MultiLocalizedUnicodeData` | `desc` |
+| `desc` | `TextDescriptionData` | `desc` |
+| `sf32` | `S15Fixed16ArrayData` | `chad` |
+| `sig ` | `SignatureData` | `tech` |
+| `text` | `TextData` | `cprt` |
+| `mft1` | `Lut8Data` | `A2B0`, `B2A0` |
+| `mft2` | `Lut16Data` | `A2B0`, `B2A0` |
+
+Tags not yet parsed are stored as `RawData` and written back verbatim — no data is lost.
+
+## Key Types
+
+| Type | Description |
+|---|---|
+| [`S15Fixed16`] | ICC s15Fixed16 fixed-point number used in matrices and XYZ values |
+| [`profile::Profile`] | Parsed profile, dispatched to one of eight device-class variants |
+| [`profile::TagSetter`] | Consuming builder returned by `with_tag(…)` |
+| [`tag::TagSignature`] | 4-byte tag identifier; 70+ known signatures plus `Unknown(u32)` |
+| [`error::Error`] | Top-level error type |
+
+## Lossless Round-trips
+
+Any tag not recognised by this crate is preserved as raw bytes and written back verbatim.
+Reading a profile and re-serialising it produces byte-identical output.
+
+## CLI Tool
+
+The `cmx` binary prints any ICC profile as TOML:
 
 ```bash
 cargo install cmx
+cmx profile.icc               # print TOML to stdout
+cmx profile.icc -o out.toml   # write TOML to a file
 ```
 
-To use the `cmx` library in your Rust project:
+## Installation
+
+Add the library to your project:
 
 ```bash
 cargo add cmx
 ```
 
-Documentation is available at [docs.rs/cmx](https://docs.rs/cmx).
+Full API documentation is on [docs.rs/cmx](https://docs.rs/cmx).
 
-### Roadmap
+## Roadmap
 
-- [x] Parse full ICC profiles
-- [x] Convert to TOML format
-- [x] Add builder-style API for constructing ICC profiles
-- [x] Support basic ICC Type tags and color models
-- [ ] Read TOML Color profiles and convert to binary ICC profiles
-- [ ] Utilities for commandline profile conversion and manipulation
-- [ ] Calibration and profiling tools
-- [ ] X-Rite I1 Profiler support
-- [ ] Support all ICC Type tags
-- [ ] Enable spectral data and advanced color management
-
-
-
-### Overview
-
-Although the ICC specification is broad and complex, this crate aims
-to provide a robust foundation for working with ICC profiles in Rust.
-
-It supports parsing, constructing, and changing of the primary ICC-defined tags,
-as well as some commonly used non-standard tags.
-
-Even tags that cannot yet be parsed are still preserved when reading
-and serializing profiles, ensuring no data loss.
-
-The long-term goal is to fully support advanced ICC color management,
-including spectral data and extended color models, while maintaining
-compatibility with existing profiles.
+- [x] Parse full ICC profiles (versions 2.x–5.0)
+- [x] Lossless round-trips — unknown tags preserved verbatim
+- [x] Conversion to human-readable TOML format
+- [x] Builder-style API for constructing ICC profiles
+- [x] Support for the primary ICC tag types
+- [ ] Read TOML color profiles and convert back to binary ICC
+- [ ] Support all ICC tag types
+- [ ] Spectral data and ICC v5 color management
 
 <!-- cargo-rdme end -->
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -40,9 +40,9 @@ pub enum Error {
     #[error("Is not a {0}")]
     IsNotA(&'static str),
 
-    /// The bytes passed to [`RawProfile::from_bytes`] do not begin with the
-    /// mandatory `acsp` file signature or otherwise fail the minimum structural
-    /// checks for a valid ICC profile.
+    /// The bytes passed to [`RawProfile::from_bytes`](crate::profile::RawProfile::from_bytes)
+    /// do not begin with the mandatory `acsp` file signature or otherwise fail the minimum
+    /// structural checks for a valid ICC profile.
     #[error("This is not a valid ICC profile")]
     InvalidICCProfile,
 
@@ -50,20 +50,20 @@ pub enum Error {
     /// out-of-range values (e.g. month 13, hour 25).  The inner string
     /// contains the raw date as read from the header.
     ///
-    /// Returned by [`RawProfile::creation_date`].
+    /// Returned by [`RawProfile::creation_date`](crate::profile::RawProfile::creation_date).
     #[error("Invalid date/time in ICC profile header: {0}")]
     InvalidDate(String),
 
-    /// [`ParametricCurveData::set_parameters_slice`] was called with a slice
-    /// whose length is not one of the five ICC-defined counts (1, 3, 4, 5, or 7).
-    /// Each count corresponds to a specific parametric curve function type in
-    /// the ICC specification (Table 68 in ICC.1:2022).
+    /// [`ParametricCurveData::set_parameters_slice`](crate::tag::tagdata::ParametricCurveData::set_parameters_slice)
+    /// was called with a slice whose length is not one of the five ICC-defined counts
+    /// (1, 3, 4, 5, or 7).  Each count corresponds to a specific parametric curve function
+    /// type in the ICC specification (Table 68 in ICC.1:2022).
     #[error("Unsupported parametric curve parameter count: {0} (must be 1, 3, 4, 5, or 7)")]
     UnsupportedParameterCount(usize),
 
-    /// [`RawProfile::into_bytes`] produced a serialised profile whose size
-    /// exceeds 2^32 − 1 bytes.  The ICC specification stores the profile size
-    /// in a 32-bit field, so larger profiles cannot be represented.
+    /// [`RawProfile::into_bytes`](crate::profile::RawProfile::into_bytes) produced a
+    /// serialised profile whose size exceeds 2^32 − 1 bytes.  The ICC specification stores
+    /// the profile size in a 32-bit field, so larger profiles cannot be represented.
     #[error("Profile exceeds maximum ICC size of 4 GiB ({0} bytes)")]
     ProfileTooLarge(usize),
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -5,7 +5,7 @@ use crate::signatures::Signature;
 
 /// The top-level error type returned by most public API functions in this crate.
 ///
-/// All variants are non-exhaustive — new variants may be added in future releases
+/// This enum is non-exhaustive — new variants may be added in future releases
 /// without a semver-breaking change.
 #[derive(thiserror::Error, Debug, PartialEq)]
 #[non_exhaustive]

--- a/src/error.rs
+++ b/src/error.rs
@@ -3,35 +3,76 @@
 
 use crate::signatures::Signature;
 
+/// The top-level error type returned by most public API functions in this crate.
+///
+/// All variants are non-exhaustive — new variants may be added in future releases
+/// without a semver-breaking change.
 #[derive(thiserror::Error, Debug, PartialEq)]
 #[non_exhaustive]
 pub enum Error {
+    /// A lower-level error produced while parsing the 128-byte ICC profile header.
+    /// Carries a human-readable description of the specific field that failed.
     #[error(transparent)]
     HeaderParseError(#[from] HeaderParseError),
 
+    /// A general string-parsing error, e.g. when converting a tag field to a
+    /// Rust `String` fails.
     #[error(transparent)]
     ParseError(#[from] ParseError),
 
+    /// The CMM (Color Management Module) signature field contains a value that
+    /// is not recognised by this crate.
     #[error(transparent)]
     InvalidCmmError(#[from] InvalidCmmError),
 
+    /// A CMM value was rejected for a reason described by the contained string.
     #[error("Invalid CMM: {0}")]
     InvalidCmm(&'static str),
 
+    /// The Profile Connection Space (PCS) tag carries an unrecognised 4-byte
+    /// signature.  Valid values are `XYZ ` and `Lab `.
     #[error("Invalid ICC Profile signature: {0}")]
     InvalidPcsTag(Signature),
+
+    /// Returned by `TryFrom` conversions between `Profile` and a specific
+    /// device-class wrapper (e.g. `DisplayProfile`) when the profile's
+    /// `DeviceClass` field does not match the target type.
     #[error("Is not a {0}")]
     IsNotA(&'static str),
+
+    /// The bytes passed to [`RawProfile::from_bytes`] do not begin with the
+    /// mandatory `acsp` file signature or otherwise fail the minimum structural
+    /// checks for a valid ICC profile.
     #[error("This is not a valid ICC profile")]
     InvalidICCProfile,
+
+    /// The creation date/time fields in the ICC profile header contain
+    /// out-of-range values (e.g. month 13, hour 25).  The inner string
+    /// contains the raw date as read from the header.
+    ///
+    /// Returned by [`RawProfile::creation_date`].
+    #[error("Invalid date/time in ICC profile header: {0}")]
+    InvalidDate(String),
+
+    /// [`ParametricCurveData::set_parameters_slice`] was called with a slice
+    /// whose length is not one of the five ICC-defined counts (1, 3, 4, 5, or 7).
+    /// Each count corresponds to a specific parametric curve function type in
+    /// the ICC specification (Table 68 in ICC.1:2022).
+    #[error("Unsupported parametric curve parameter count: {0} (must be 1, 3, 4, 5, or 7)")]
+    UnsupportedParameterCount(usize),
+
+    /// [`RawProfile::into_bytes`] produced a serialised profile whose size
+    /// exceeds 2^32 − 1 bytes.  The ICC specification stores the profile size
+    /// in a 32-bit field, so larger profiles cannot be represented.
+    #[error("Profile exceeds maximum ICC size of 4 GiB ({0} bytes)")]
+    ProfileTooLarge(usize),
 }
 
-/// Generates a `new()` constructor and a `From<&str>` impl
-/// for an error wrapper around a `String`.
+/// Generates a newtype error struct wrapping a `String`, with a `new()` constructor
+/// and a `From<&str>` impl for convenient construction from string literals.
 ///
-/// Usage:
-///
-/// ```
+/// Used internally to create [`HeaderParseError`], [`ParseError`], and
+/// [`InvalidCmmError`].
 macro_rules! define_string_error {
     ($name:ident, $msg:literal) => {
         #[derive(thiserror::Error, Debug, PartialEq)]

--- a/src/header.rs
+++ b/src/header.rs
@@ -293,17 +293,22 @@ impl RawProfile {
     /// Returns the creation date of the profile.
     /// This method extracts the creation date from the profile header and returns it as a `DateTime<chrono::Utc>`.
     ///
+    /// # Errors
+    ///
+    /// Returns [`Error::InvalidDate`] if the header contains out-of-range date/time fields
+    /// (e.g. month 13, hour 25).
+    ///
     /// # Example:
     /// ```rust
     /// use cmx::profile::RawProfile;
     /// use chrono::{DateTime, Datelike, Utc};
     /// let profile = RawProfile::read("tests/profiles/Display P3.icc").unwrap();
-    /// let creation_date = profile.creation_date();
+    /// let creation_date = profile.creation_date().unwrap();
     /// assert_eq!(creation_date.year(), 2017);
     /// assert_eq!(creation_date.month(), 7);
     /// assert_eq!(creation_date.day(), 7);
     /// ```
-    pub fn creation_date(&self) -> DateTime<chrono::Utc> {
+    pub fn creation_date(&self) -> Result<DateTime<chrono::Utc>, Error> {
         let header = self.header();
         let year = header.creation_year.get() as i32;
         let month = header.creation_month.get() as u32;
@@ -313,9 +318,12 @@ impl RawProfile {
         let second = header.creation_seconds.get() as u32;
         let naive = chrono::NaiveDate::from_ymd_opt(year, month, day)
             .and_then(|d| d.and_hms_opt(hour, minute, second))
-            .unwrap_or_else(|| panic!("Invalid date in ICC header: {year}-{month:02}-{day:02} {hour:02}:{minute:02}:{second:02}"));
-        // .expect(format!("Invalid date in ICC header: {year}-{month:02}-{day:02} {hour:02}:{minute:02}:{second:02}").as_ref());
-        DateTime::from_naive_utc_and_offset(naive, chrono::Utc)
+            .ok_or_else(|| {
+                Error::InvalidDate(format!(
+                    "{year}-{month:02}-{day:02} {hour:02}:{minute:02}:{second:02}"
+                ))
+            })?;
+        Ok(DateTime::from_naive_utc_and_offset(naive, chrono::Utc))
     }
 
     /// Sets the creation date of the profile.
@@ -336,7 +344,10 @@ impl RawProfile {
     }
 
     pub fn with_now_as_creation_date(self) -> Self {
-        let now = chrono::Utc::now().with_nanosecond(0).unwrap();
+        // with_nanosecond(0) only returns None for out-of-range values; 0 is always valid.
+        let now = chrono::Utc::now()
+            .with_nanosecond(0)
+            .expect("nanosecond 0 is always valid");
         self.with_creation_date(now)
     }
 

--- a/src/header/parsed_header.rs
+++ b/src/header/parsed_header.rs
@@ -119,7 +119,10 @@ impl From<&super::RawProfile> for Header {
             device_class: raw_profile.device_class().to_string(),
             color_space: raw_profile.data_color_space().map(|c| c.to_string()),
             pcs: raw_profile.pcs().unwrap().to_string(),
-            creation_datetime: raw_profile.creation_date().to_string(),
+            creation_datetime: raw_profile
+                .creation_date()
+                .map(|d| d.to_string())
+                .unwrap_or_else(|e| format!("<invalid: {e}>")),
             primary_platform: raw_profile.primary_platform().map(|c| c.to_string()),
             embedded,
             use_embedded_only,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,23 +4,41 @@
 //#![allow(dead_code, unused_imports)]
 
 /*!
-This crate provides utilities for working with ICC color profiles
-and integrates with the Colorimetry Library.
+`cmx` is a Rust library for reading, writing, and constructing [ICC color profiles][icc-spec]
+(versions 2.0–5.0).  ICC profiles describe how color values produced by a device (camera,
+display, printer) relate to a standard reference color space, making them essential for
+accurate color reproduction across devices and applications.
 
-## Use Cases
-<details><summary><strong>Parsing ICC profiles and conversion to TOML format for analysis</strong></summary>
-After installing the library, you can parse an ICC profile and convert it to a TOML format using the `cmx` command-line tool:
+[icc-spec]: https://www.color.org/specification/ICC.1-2022-05.pdf
 
-```bash
-cmx profile.icc -o profile.toml
+# Quick Start
+
+## Read a profile from disk
+
+```no_run
+use cmx::profile::Profile;
+
+let profile = Profile::read("profile.icc")?;
+println!("Color space : {:?}", profile.data_color_space());
+println!("PCS         : {:?}", profile.pcs());
+println!("Version     : {:?}", profile.version()?);
+# Ok::<(), Box<dyn std::error::Error>>(())
 ```
 
-Each ICC profile tag is mapped to a key in the TOML file, with the
-corresponding values serialized as key-value pairs.
-All values are written as single-line entries to ensure the TOML output
-remains human-readable and easy to inspect.
+## Dump a profile as TOML
 
-Example of a parsed ICC profile in TOML format:
+The [`fmt::Display`](std::fmt::Display) implementation on every profile type serialises it
+to TOML — the same output produced by the `cmx` CLI tool:
+
+```no_run
+use cmx::profile::Profile;
+
+let profile = Profile::read("profile.icc")?;
+println!("{profile}");
+# Ok::<(), Box<dyn std::error::Error>>(())
+```
+
+The output looks like:
 
 ```toml
 profile_size = 548
@@ -40,20 +58,8 @@ profile_id = "53410ea9facdd9fb57cc74868defc33f"
 [desc]
 ascii = "SMPTE RP 431-2-2007 DCI (P3)"
 
-[cprt]
-text = "Copyright Apple Inc., 2015"
-
 [wtpt]
 xyz = [0.894592, 1.0, 0.954422]
-
-[rXYZ]
-xyz = [0.48616, 0.226685, -0.000809]
-
-[gXYZ]
-xyz = [0.323853, 0.710327, 0.043228]
-
-[bXYZ]
-xyz = [0.15419, 0.062988, 0.782471]
 
 [rTRC]
 g = 2.60001
@@ -64,32 +70,19 @@ matrix = [
     [0.055573, 0.963989, -0.014343],
     [-0.004272, 0.005295, 0.862778]
 ]
+```
 
-[bTRC]
-g = 2.60001
+## Build a profile from scratch
 
-[gTRC]
-g = 2.60001
-
- ```
-</details>
-
-<details><summary><strong>Generate ICC profiles</strong></summary>
-
-You can also use the `cmx` library to create ICC profiles from scratch, or read existing
-profiles and change them, using Rust.
-
-The library provides a builder-style API for constructing, or read and change profiles,
-allowing you to set or change various tags and properties.
-
-Here is an example for creating a Display P3 ICC profile:
+The consuming builder API sets tags one by one and computes the profile ID at the end:
 
 ```rust
 use chrono::{DateTime, TimeZone};
 use cmx::tag::tags::*;
 use cmx::profile::DisplayProfile;
+
 let display_p3_example = DisplayProfile::new()
-    // set creation date, if omitted, the current date and time are used
+    // set creation date — current date/time is used if omitted
     .with_creation_date(chrono::Utc.with_ymd_and_hms(2025, 8, 28, 0, 0, 0).unwrap())
     .with_tag(ProfileDescriptionTag)
         .as_text_description(|text| {
@@ -135,72 +128,152 @@ let display_p3_example = DisplayProfile::new()
                 -0.009232, 0.015076,  0.751678
             ]);
         })
-    .with_profile_id() // calculate and add profile ID to the profile
-    ;
+    .with_profile_id(); // compute and embed the MD5 profile ID
 
-display_p3_example.write("tmp/display_p3_example.icc").unwrap();
-let display_p3_read_back = cmx::profile::Profile::read("tmp/display_p3_example.icc").unwrap();
-assert_eq!(
-    display_p3_read_back.profile_id_as_hex_string(),
-    "617028e1 e1014e15 91f178a9 fb8efc92"
-);
-assert_eq!(display_p3_read_back.profile_size(), 524);
+// Serialise to bytes without touching the filesystem
+let bytes = display_p3_example.to_bytes().unwrap();
+assert_eq!(bytes.len(), 524);
 ```
 
-Not all ICC tag types are supported yet, but please submit a pull request, or an issue, on our
-[GitHub CMX repo](https://github.com/harbik/cmx) if you want additional tag types to be supported.
+## Modify an existing profile
 
-However, you can use the `as_raw` method to set raw data for tags that are not yet supported.
+Read a profile, change a tag, and write it back:
 
-</details>
+```no_run
+use cmx::profile::Profile;
+use cmx::tag::tags::CopyrightTag;
 
+Profile::read("input.icc")?
+    .with_tag(CopyrightTag)
+        .as_text(|t| t.set_text("Copyright 2025 Acme Corp."))
+    .write("output.icc")?;
+# Ok::<(), Box<dyn std::error::Error>>(())
+```
 
+# Modules
 
-## Installation
+| Module | Contents |
+|---|---|
+| [`profile`] | `Profile` enum and per-device-class types (`DisplayProfile`, `InputProfile`, …) |
+| [`tag`] | Tag signatures, tag data types, and the `TagSetter` builder |
+| [`header`] | ICC 128-byte header fields and accessors |
+| [`signatures`] | ICC 4-byte signature enums (`ColorSpace`, `DeviceClass`, `RenderingIntent`, …) |
+| [`error`] | [`Error`] type returned by public API functions |
 
-Install the `cmx` tool using Cargo:
+# ICC Profile Concepts
+
+An ICC profile is a binary file with three sections:
+
+1. **128-byte header** — fixed fields: device class, color space, PCS, version, creation date, etc.
+2. **Tag table** — a list of `(signature, offset, size)` entries pointing into the data block.
+3. **Tag data** — the actual payload for each tag (matrices, curves, look-up tables, text, …).
+
+## Device Classes
+
+The ICC specification defines eight device classes.  This crate provides a dedicated type for each:
+
+| Type | ICC class code | Typical use |
+|---|---|---|
+| [`profile::DisplayProfile`] | `mntr` | Monitors, projectors |
+| [`profile::InputProfile`] | `scnr` | Cameras, scanners |
+| [`profile::OutputProfile`] | `prtr` | Printers |
+| [`profile::DeviceLinkProfile`] | `link` | Direct device-to-device transforms |
+| [`profile::AbstractProfile`] | `abst` | Abstract color transforms |
+| [`profile::ColorSpaceProfile`] | `spac` | Color space definitions |
+| [`profile::NamedColorProfile`] | `nmcl` | Named color palettes |
+| [`profile::SpectralProfile`] | `cenc` | Spectral data (ICC v5) |
+
+All types wrap a [`profile::RawProfile`] which holds the raw binary data and
+preserves unknown tags verbatim, guaranteeing lossless round-trips.
+
+## Profile Connection Space (PCS)
+
+Profiles connect device-specific color values to a common reference color space called the
+**Profile Connection Space (PCS)**.  Two PCS values are defined by the ICC specification:
+
+- `XYZ` — CIE 1931 XYZ, used by most display and output profiles.
+- `Lab` — CIELAB (L\*a\*b\*), used by some output and abstract profiles.
+
+## Rendering Intents
+
+The rendering intent controls how out-of-gamut colors are handled during color conversion.
+Four intents are defined:
+
+| Intent | Typical use |
+|---|---|
+| Perceptual | Photographic images — compresses the gamut smoothly |
+| Relative Colorimetric | Graphics — clips and maps the source white point |
+| Saturation | Business graphics — maximises saturation |
+| Absolute Colorimetric | Proofing — preserves absolute colorimetric values |
+
+## Tags
+
+Tags are identified by a 4-byte signature (e.g. `rXYZ`, `rTRC`, `desc`).  Each tag carries a
+payload of a specific ICC type — an XYZ triplet, a tone-reproduction curve, a text string, etc.
+All well-known tag signatures are re-exported from [`tag::tags`].
+
+Tag types supported for reading and writing include:
+
+| ICC type | Rust type | Common tags |
+|---|---|---|
+| `XYZ` | `XYZArrayData` | `rXYZ`, `gXYZ`, `bXYZ`, `wtpt` |
+| `para` | `ParametricCurveData` | `rTRC`, `gTRC`, `bTRC` |
+| `curv` | `CurveData` | `rTRC`, `gTRC`, `bTRC` |
+| `mluc` | `MultiLocalizedUnicodeData` | `desc` |
+| `desc` | `TextDescriptionData` | `desc` |
+| `sf32` | `S15Fixed16ArrayData` | `chad` |
+| `sig ` | `SignatureData` | `tech` |
+| `text` | `TextData` | `cprt` |
+| `mft1` | `Lut8Data` | `A2B0`, `B2A0` |
+| `mft2` | `Lut16Data` | `A2B0`, `B2A0` |
+
+Tags not yet parsed are stored as `RawData` and written back verbatim — no data is lost.
+
+# Key Types
+
+| Type | Description |
+|---|---|
+| [`S15Fixed16`] | ICC s15Fixed16 fixed-point number used in matrices and XYZ values |
+| [`profile::Profile`] | Parsed profile, dispatched to one of eight device-class variants |
+| [`profile::TagSetter`] | Consuming builder returned by `with_tag(…)` |
+| [`tag::TagSignature`] | 4-byte tag identifier; 70+ known signatures plus `Unknown(u32)` |
+| [`error::Error`] | Top-level error type |
+
+# Lossless Round-trips
+
+Any tag not recognised by this crate is preserved as raw bytes and written back verbatim.
+Reading a profile and re-serialising it produces byte-identical output.
+
+# CLI Tool
+
+The `cmx` binary prints any ICC profile as TOML:
 
 ```bash
 cargo install cmx
+cmx profile.icc               # print TOML to stdout
+cmx profile.icc -o out.toml   # write TOML to a file
 ```
 
-To use the `cmx` library in your Rust project:
+# Installation
+
+Add the library to your project:
 
 ```bash
 cargo add cmx
 ```
 
-Documentation is available at [docs.rs/cmx](https://docs.rs/cmx).
+Full API documentation is on [docs.rs/cmx](https://docs.rs/cmx).
 
-## Roadmap
+# Roadmap
 
-- [x] Parse full ICC profiles
-- [x] Convert to TOML format
-- [x] Add builder-style API for constructing ICC profiles
-- [x] Support basic ICC Type tags and color models
-- [ ] Read TOML Color profiles and convert to binary ICC profiles
-- [ ] Utilities for commandline profile conversion and manipulation
-- [ ] Calibration and profiling tools
-- [ ] X-Rite I1 Profiler support
-- [ ] Support all ICC Type tags
-- [ ] Enable spectral data and advanced color management
-
-
-
-## Overview
-
-Although the ICC specification is broad and complex, this crate aims
-to provide a robust foundation for working with ICC profiles in Rust.
-
-It supports parsing, constructing, and changing of the primary ICC-defined tags,
-as well as some commonly used non-standard tags.
-
-Even tags that cannot yet be parsed are still preserved when reading
-and serializing profiles, ensuring no data loss.
-
-The long-term goal is to fully support advanced ICC color management,
-including spectral data and extended color models, while maintaining
-compatibility with existing profiles.
+- [x] Parse full ICC profiles (versions 2.x–5.0)
+- [x] Lossless round-trips — unknown tags preserved verbatim
+- [x] Conversion to human-readable TOML format
+- [x] Builder-style API for constructing ICC profiles
+- [x] Support for the primary ICC tag types
+- [ ] Read TOML color profiles and convert back to binary ICC
+- [ ] Support all ICC tag types
+- [ ] Spectral data and ICC v5 color management
 */
 
 pub mod error;
@@ -293,13 +366,20 @@ pub fn parse_hex_string(s: &str) -> Result<Vec<u8>, hex::FromHexError> {
 }
 
 use zerocopy::{BigEndian, FromBytes, Immutable, IntoBytes, KnownLayout, Unaligned, I32};
+
+/// An ICC `s15Fixed16Number`: a signed 32-bit fixed-point value with 15 integer bits and
+/// 16 fractional bits, stored in big-endian byte order.
+///
+/// The value `v` is encoded as `round(v × 65536)`.  The representable range is roughly
+/// `[−32768, 32767.99998]`.  This type is used throughout ICC profiles for XYZ tristimulus
+/// values, chromatic-adaptation matrices, and parametric curve parameters.
+///
+/// Conversion to and from `f64` is provided via the standard [`From`] trait.  Values are
+/// rounded to 5 decimal places on conversion to avoid floating-point noise.
 #[derive(FromBytes, IntoBytes, Unaligned, KnownLayout, Immutable, Debug, Clone, Copy)]
 #[repr(C)]
 pub struct S15Fixed16(I32<BigEndian>);
 
-/// A 15.16 fixed-point number, where the first 15 bits are the integer part and the last 16 bits are the fractional part.
-/// This is used in ICC profiles to represent color values.
-/// The value is stored as a 32-bit signed integer in big-endian format.
 impl From<S15Fixed16> for f64 {
     fn from(value: S15Fixed16) -> Self {
         let s15 = value.0.get();

--- a/src/profile.rs
+++ b/src/profile.rs
@@ -45,6 +45,27 @@ use crate::{header::Header, tag::ParsedTag};
 
 pub use {checksum::md5checksum, checksum::set_profile_id};
 
+/// A parsed ICC color profile, represented as one of the eight device classes
+/// defined by the ICC specification, plus a catch-all [`Profile::Raw`] variant
+/// for profiles whose device-class field is not recognised.
+///
+/// Use [`Profile::read`] or [`Profile::from_bytes`] to parse an existing profile.
+/// Use the device-class constructors (e.g. [`DisplayProfile::new`]) and the builder
+/// API when constructing a new profile from scratch.
+///
+/// # Device classes
+///
+/// | Variant | ICC class | Typical use |
+/// |---|---|---|
+/// | [`Profile::Input`] | `scnr` | Scanners, cameras |
+/// | [`Profile::Display`] | `mntr` | Monitors, displays |
+/// | [`Profile::Output`] | `prtr` | Printers |
+/// | [`Profile::DeviceLink`] | `link` | Direct device-to-device conversion |
+/// | [`Profile::Abstract`] | `abst` | Abstract color transform |
+/// | [`Profile::ColorSpace`] | `spac` | Color space definition |
+/// | [`Profile::NamedColor`] | `nmcl` | Named color palettes |
+/// | [`Profile::Spectral`] | `cenc` | Spectral data (ICC v5) |
+/// | [`Profile::Raw`] | — | Unrecognised device class |
 #[derive(Debug)]
 pub enum Profile {
     Input(InputProfile),
@@ -59,6 +80,7 @@ pub enum Profile {
 }
 
 impl Profile {
+    /// Unwrap into the underlying [`RawProfile`], consuming `self`.
     fn into_raw_profile(self) -> RawProfile {
         match self {
             Profile::Input(p) => p.0,
@@ -87,7 +109,7 @@ impl Profile {
         }
     }
 
-    // Add mutable access to the underlying RawProfile for enum variants.
+    /// Return a shared reference to the underlying [`RawProfile`].
     fn as_raw_profile_mut(&mut self) -> &mut RawProfile {
         match self {
             Profile::Input(p) => &mut p.0,
@@ -102,7 +124,13 @@ impl Profile {
         }
     }
 
-    // Read-only getters delegated to RawProfile.
+    // -----------------------------------------------------------------------
+    // Read-only accessors — all delegate to the underlying RawProfile.
+    // -----------------------------------------------------------------------
+
+    /// Returns the ICC profile version as `(major, minor)`.
+    /// Errors if the version stored in the header is not one of the values
+    /// recognised by this crate (2.x, 4.x, 5.0).
     pub fn version(&self) -> Result<(u8, u8), crate::Error> {
         self.as_raw_profile().version()
     }
@@ -125,20 +153,30 @@ impl Profile {
         self.as_raw_profile().model()
     }
 
+    /// Parse an ICC profile from a raw byte slice, returning the appropriate
+    /// device-class variant.  Unknown device classes are returned as
+    /// [`Profile::Raw`].
     pub fn from_bytes(bytes: &[u8]) -> Result<Self, Box<dyn std::error::Error>> {
         let raw = RawProfile::from_bytes(bytes)?;
         Ok(raw.into_class_profile())
     }
 
+    /// Read an ICC profile from a file on disk, returning the appropriate
+    /// device-class variant.
     pub fn read(path: impl AsRef<std::path::Path>) -> Result<Self, Box<dyn std::error::Error>> {
         let raw = RawProfile::read(path)?;
         Ok(raw.into_class_profile())
     }
 
+    /// Serialise the profile to a byte vector ready for writing to disk or
+    /// embedding in an image.  Recalculates tag offsets and, if
+    /// [`with_profile_id`](RawProfile::with_profile_id) was called, the MD5
+    /// profile ID.
     pub fn into_bytes(self) -> Result<Vec<u8>, Box<dyn std::error::Error>> {
         self.into_raw_profile().into_bytes()
     }
 
+    /// Serialise the profile and write it to the given path.
     pub fn write(
         self,
         path: impl AsRef<std::path::Path>,
@@ -146,6 +184,8 @@ impl Profile {
         self.into_raw_profile().write(path)
     }
 
+    /// Returns the raw 16-byte profile ID (MD5 checksum of the profile bytes
+    /// with the ID field zeroed).  All zeros means no ID has been computed.
     pub fn profile_id(&self) -> [u8; 16] {
         self.as_raw_profile().profile_id()
     }
@@ -154,7 +194,7 @@ impl Profile {
         self.as_raw_profile().profile_id_as_hex_string()
     }
 
-    pub fn creation_date(&self) -> chrono::DateTime<chrono::Utc> {
+    pub fn creation_date(&self) -> Result<chrono::DateTime<chrono::Utc>, crate::Error> {
         self.as_raw_profile().creation_date()
     }
     pub fn pcs_illuminant(&self) -> [f64; 3] {
@@ -167,7 +207,12 @@ impl Profile {
         self.as_raw_profile().cmm()
     }
 
-    // Consuming builders: forward to the matching wrapper and re-wrap.
+    // -----------------------------------------------------------------------
+    // Consuming builders — forward to the matching device-class wrapper and re-wrap.
+    // -----------------------------------------------------------------------
+
+    /// Set the ICC version.  Returns an error for any version not recognised
+    /// by this crate.  See [`RawProfile::with_version`] for supported values.
     pub fn with_version(self, major: u8, minor: u8) -> Result<Self, crate::Error> {
         Ok(match self {
             Profile::Input(p) => Profile::Input(p.with_version(major, minor)?),
@@ -196,7 +241,18 @@ impl Profile {
         }
     }
 
-    // Consuming builder entry for tags, returning TagSetter bound to this enum.
+    /// Begin setting the data for a specific tag, returning a [`TagSetter`]
+    /// that provides type-safe `as_*` methods for the chosen tag.
+    ///
+    /// # Example
+    /// ```rust
+    /// use cmx::profile::DisplayProfile;
+    /// use cmx::tag::tags::MediaWhitePointTag;
+    ///
+    /// let profile = DisplayProfile::new()
+    ///     .with_tag(MediaWhitePointTag)
+    ///     .as_xyz_array(|xyz| xyz.set([0.9505, 1.0, 1.0890]));
+    /// ```
     pub fn with_tag<S: Into<crate::tag::TagSignature> + Copy>(
         self,
         signature: S,

--- a/src/profile.rs
+++ b/src/profile.rs
@@ -109,7 +109,7 @@ impl Profile {
         }
     }
 
-    /// Return a shared reference to the underlying [`RawProfile`].
+    /// Return a mutable reference to the underlying [`RawProfile`].
     fn as_raw_profile_mut(&mut self) -> &mut RawProfile {
         match self {
             Profile::Input(p) => &mut p.0,

--- a/src/profile/delegate.rs
+++ b/src/profile/delegate.rs
@@ -14,7 +14,7 @@ macro_rules! delegate_raw_profile_methods {
                     to self.0 {
                         pub fn apple_flags(&self) -> (crate::tag::Quality, crate::tag::Interpolate, crate::tag::GamutCheck);
                         pub fn cmm(&self) -> Option<crate::signatures::Cmm>;
-                        pub fn creation_date(&self) -> chrono::DateTime<chrono::Utc>;
+                        pub fn creation_date(&self) -> Result<chrono::DateTime<chrono::Utc>, crate::Error>;
                         pub fn data_color_space(&self) -> Option<crate::signatures::ColorSpace>;
                         pub fn flags(&self) -> (bool, bool);
                         pub fn manufacturer(&self) -> Option<crate::signatures::Signature>;

--- a/src/profile/display_profile.rs
+++ b/src/profile/display_profile.rs
@@ -90,7 +90,7 @@ impl DisplayProfile {
         let pcs_illuminant = display_profile.pcs_illuminant(); // always D50
         let obs = colorimetry::observer::Observer::Cie1931;
         let pcs_illuminant_xyz = colorimetry::xyz::XYZ::new(pcs_illuminant, obs);
-        let media_white_xyz = rgb_space.white_point(obs).set_illuminance(1.0).values();
+        let media_white_xyz = rgb_space.white_point(obs).set_illuminance(1.0).to_array();
         let m_rgb = obs.calc_rgb2xyz_matrix_with_alt_white(rgb_space, Some(pcs_illuminant_xyz));
         let r_xyz = m_rgb.column(0);
         let g_xyz = m_rgb.column(1);

--- a/src/profile/display_profile.rs
+++ b/src/profile/display_profile.rs
@@ -59,13 +59,15 @@ impl TryFrom<Profile> for DisplayProfile {
 }
 
 impl DisplayProfile {
-    /// Creates a new, empty, `InputProfile` with
+    /// Creates a new, empty `DisplayProfile` with:
     ///
-    /// - the default `RawProfile` with
-    ///   - the ICC profile signature
-    ///   - version set to 4.3
-    ///   - the current date
-    /// - `DeviceClass` set to `Display`
+    /// - the default [`RawProfile`] defaults: valid `acsp` signature, version 4.3,
+    ///   and the current date as the creation timestamp
+    /// - `DeviceClass` set to `Display` (`mntr`)
+    /// - `ColorSpace` set to `RGB`
+    ///
+    /// All tags must be added explicitly via the builder API before the profile
+    /// can be used with a Color Management System.
     pub fn new() -> Self {
         Self(
             Self(RawProfile::default())
@@ -133,15 +135,18 @@ impl DisplayProfile {
                 })
             .with_tag(RedTRCTag)
                 .as_parametric_curve(|para| {
-                    para.set_parameters_slice(gamma_values);
+                    para.set_parameters_slice(gamma_values)
+                        .expect("gamma_values has a valid ICC parametric curve parameter count");
                 })
             .with_tag(BlueTRCTag)
                 .as_parametric_curve(|para| {
-                    para.set_parameters_slice(gamma_values);
+                    para.set_parameters_slice(gamma_values)
+                        .expect("gamma_values has a valid ICC parametric curve parameter count");
                 })
             .with_tag(GreenTRCTag)
                 .as_parametric_curve(|para| {
-                    para.set_parameters_slice(gamma_values);
+                    para.set_parameters_slice(gamma_values)
+                        .expect("gamma_values has a valid ICC parametric curve parameter count");
                 })
             .with_profile_id()
     }

--- a/src/profile/raw_profile.rs
+++ b/src/profile/raw_profile.rs
@@ -3,7 +3,7 @@
 
 use indexmap::IndexMap;
 use serde::Serialize;
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::fs::File;
 use std::io::{Cursor, Read, Write};
 use std::path::Path;
@@ -128,15 +128,31 @@ impl Default for RawProfile {
 }
 
 // Accept a slice to avoid needless Vec typing.
-fn share_tags(tag_entries: &[(TagSignature, u32, u32)]) -> bool {
-    // Duplicate offsets in the tag table imply shared data blocks.
-    let mut seen_offsets = HashSet::new();
-    for &(_sig, offset, _size) in tag_entries {
-        if !seen_offsets.insert(offset) {
-            return true;
+// Returns Ok(true) when the profile uses shared tag data (multiple tag table entries pointing
+// to the same offset with the same size).
+// Returns Err if two entries share an offset but have different sizes — that is a corrupt profile.
+fn share_tags(tag_entries: &[(TagSignature, u32, u32)]) -> Result<bool, String> {
+    // Map from offset → size so we can detect both sharing and mismatches.
+    let mut seen: HashMap<u32, u32> = HashMap::new();
+    let mut any_shared = false;
+    for &(_sig, offset, size) in tag_entries {
+        match seen.get(&offset) {
+            None => {
+                seen.insert(offset, size);
+            }
+            Some(&prev_size) if prev_size == size => {
+                // Legitimate shared tag data block.
+                any_shared = true;
+            }
+            Some(&prev_size) => {
+                return Err(format!(
+                    "corrupt profile: two tags at offset {offset} claim different sizes \
+                     ({prev_size} vs {size})"
+                ));
+            }
         }
     }
-    false
+    Ok(any_shared)
 }
 
 /// Implementation of the `RawProfile` struct for handling ICC color profiles.
@@ -210,8 +226,12 @@ impl RawProfile {
             tag_entries.push((signature, offset, size));
         }
 
-        // Detect if the source profile used shared tag data (duplicate offsets)
-        let shared_tags = share_tags(&tag_entries);
+        // Detect if the source profile used shared tag data (duplicate offsets).
+        // Returns an error if two tags share an offset but claim different sizes (corrupt profile).
+        let shared_tags = share_tags(&tag_entries).map_err(|e| {
+            Box::new(std::io::Error::new(std::io::ErrorKind::InvalidData, e))
+                as Box<dyn std::error::Error>
+        })?;
 
         // Create a map to hold the tags
         let mut tags = IndexMap::with_capacity(tag_count as usize);
@@ -356,8 +376,9 @@ impl RawProfile {
         // All Tags written to buf, add padding if needed if the last tag does not end on a 4-byte boundary.
         buf.extend(vec![0u8; crate::pad_size(buf.len())]);
 
-        // Update profile size
-        let length = buf.len() as u32;
+        // Update profile size — the ICC spec stores this as a u32, so reject anything larger.
+        let length = u32::try_from(buf.len())
+            .map_err(|_| crate::error::Error::ProfileTooLarge(buf.len()))?;
         buf[0..4].copy_from_slice(&length.to_be_bytes());
 
         // calculate the profile ID if requested

--- a/src/profile/tag_setter.rs
+++ b/src/profile/tag_setter.rs
@@ -11,7 +11,13 @@ use crate::{
     },
 };
 
-// Provide a way to access the inner RawProfile from wrappers and Profile enum.
+/// Provides uniform access to the underlying [`RawProfile`] from any profile
+/// wrapper type or from the [`Profile`](super::Profile) enum.
+///
+/// This trait is implemented for [`RawProfile`] itself, for every device-class
+/// wrapper ([`DisplayProfile`](super::DisplayProfile), etc.), and for the
+/// [`Profile`](super::Profile) enum, allowing the builder API to work generically
+/// over all of them.
 pub trait HasRawProfile {
     fn raw(&self) -> &RawProfile;
     fn raw_mut(&mut self) -> &mut RawProfile;
@@ -103,6 +109,11 @@ impl HasRawProfile for super::Profile {
     }
 }
 
+/// Marker trait for tag signatures whose data is stored as a
+/// `MultiLocalizedUnicodeData` (ICC type `mluc`).
+///
+/// Implemented for: `CopyrightTag`, `ProfileDescriptionTag`,
+/// `DeviceMfgDescTag`, `DeviceModelDescTag`, `ViewingCondDescTag`.
 pub trait IsMultiLocalizedUnicodeTag {}
 impl IsMultiLocalizedUnicodeTag for crate::tag::tags::CopyrightTag {}
 impl IsMultiLocalizedUnicodeTag for crate::tag::tags::ProfileDescriptionTag {}
@@ -112,18 +123,27 @@ impl IsMultiLocalizedUnicodeTag for crate::tag::tags::ViewingCondDescTag {}
 #[cfg(feature = "v5")]
 impl IsMultiLocalizedUnicodeTag for crate::tag::tags::ScreeningDescTag {}
 
+/// Marker trait for tone-reproduction-curve tags whose data is stored as a
+/// `CurveData` (ICC type `curv`): `RedTRCTag`, `GreenTRCTag`,
+/// `BlueTRCTag`, `GrayTRCTag`.
 pub trait IsCurveTag {}
 impl IsCurveTag for crate::tag::tags::BlueTRCTag {}
 impl IsCurveTag for crate::tag::tags::GreenTRCTag {}
 impl IsCurveTag for crate::tag::tags::RedTRCTag {}
 impl IsCurveTag for crate::tag::tags::GrayTRCTag {}
 
+/// Marker trait for tone-reproduction-curve tags whose data is stored as a
+/// `ParametricCurveData` (ICC type `para`): `RedTRCTag`, `GreenTRCTag`,
+/// `BlueTRCTag`, `GrayTRCTag`.
 pub trait IsParametricCurveTag {}
 impl IsParametricCurveTag for crate::tag::tags::BlueTRCTag {}
 impl IsParametricCurveTag for crate::tag::tags::GreenTRCTag {}
 impl IsParametricCurveTag for crate::tag::tags::RedTRCTag {}
 impl IsParametricCurveTag for crate::tag::tags::GrayTRCTag {}
 
+/// Marker trait for tags whose data is stored as a `SignatureData`
+/// (ICC type `sig `): `TechnologyTag`,
+/// `ColorimetricIntentImageStateTag`, `PerceptualRenderingIntentGamutTag`.
 pub trait IsSignatureTag {}
 impl IsSignatureTag for crate::tag::tags::ColorimetricIntentImageStateTag {}
 impl IsSignatureTag for crate::tag::tags::TechnologyTag {}
@@ -131,6 +151,8 @@ impl IsSignatureTag for crate::tag::tags::TechnologyTag {}
 impl IsSignatureTag for crate::tag::tags::SaturationRenderingIntentGamutTag {}
 impl IsSignatureTag for crate::tag::tags::PerceptualRenderingIntentGamutTag {}
 
+/// Marker trait for tags whose data is stored as an `XYZArrayData`
+/// (ICC type `XYZ `): matrix column tags, luminance, white-point, black-point.
 pub trait IsXYZArrayTag {}
 impl IsXYZArrayTag for crate::tag::tags::RedMatrixColumnTag {}
 impl IsXYZArrayTag for crate::tag::tags::GreenMatrixColumnTag {}
@@ -139,6 +161,8 @@ impl IsXYZArrayTag for crate::tag::tags::LuminanceTag {}
 impl IsXYZArrayTag for crate::tag::tags::MediaWhitePointTag {}
 impl IsXYZArrayTag for crate::tag::tags::MediaBlackPointTag {}
 
+/// Marker trait for tags whose data is stored as a `TextDescriptionData`
+/// (legacy ICC v2 type `desc`).
 pub trait IsTextDescriptionTag {}
 impl IsTextDescriptionTag for crate::tag::tags::ProfileDescriptionTag {}
 impl IsTextDescriptionTag for crate::tag::tags::CopyrightTag {}
@@ -148,23 +172,57 @@ impl IsTextDescriptionTag for crate::tag::tags::DeviceModelDescTag {}
 impl IsTextDescriptionTag for crate::tag::tags::ScreeningDescTag {}
 impl IsTextDescriptionTag for crate::tag::tags::ViewingCondDescTag {}
 
+/// Marker trait for tags whose data is stored as plain ASCII `TextData`
+/// (ICC type `text`): `CopyrightTag`, `CharTargetTag`.
 pub trait IsTextTag {}
 impl IsTextTag for crate::tag::tags::CopyrightTag {}
 impl IsTextTag for crate::tag::tags::CharTargetTag {}
 
+/// Marker trait for tags whose data is stored as an `S15Fixed16ArrayData`
+/// (ICC type `sf32`): `ChromaticAdaptationTag`.
 pub trait IsS15Fixed16ArrayTag {}
 impl IsS15Fixed16ArrayTag for crate::tag::tags::ChromaticAdaptationTag {}
 
+/// Marker trait for tags whose data is stored as `Lut8Data` (ICC type `mft1`).
 pub trait IsLut8DataTag {}
+/// Marker trait for tags whose data is stored as `Lut16Data` (ICC type `mft2`).
 pub trait IsLut16DataTag {}
+/// Marker trait for tags whose data uses the `LutAtoB` format (ICC type `mAB `).
 pub trait IsLutAtoBDataTag {}
+/// Marker trait for tags whose data uses the `LutBtoA` format (ICC type `mBA `).
 pub trait IsLutBtoADataTag {}
 
+/// Marker trait that allows any tag to be set using raw bytes via
+/// [`TagSetter::as_raw`].  Implemented for all tag signatures.
 pub trait IsRawTag {}
 
-/// A helper for safely setting the data for a specific tag signature.
-/// It is generic over the signature type `S` to enable compile-time checks,
-/// and generic over the profile type `P` to return the correct P for chaining.
+/// An intermediate builder returned by [`with_tag`](super::Profile::with_tag) that
+/// provides type-safe methods for setting the data of a specific ICC tag.
+///
+/// `TagSetter<P, S>` is generic over:
+/// - `P` — the profile type being built (e.g. [`DisplayProfile`](super::DisplayProfile),
+///   [`Profile`](super::Profile), or [`RawProfile`]).
+/// - `S` — the tag signature type (one of the zero-sized structs in
+///   [`cmx::tag::tags`](crate::tag::tags)).
+///
+/// Each `as_*` method is gated by a marker trait (e.g. [`IsCurveTag`]) that is
+/// only implemented for the tag signatures where that data format is valid.
+/// Attempting to call `as_curve()` on a tag signature that does not implement
+/// [`IsCurveTag`] is a **compile-time error**, not a runtime one.
+///
+/// Calling an `as_*` method consumes the `TagSetter` and returns the profile `P`,
+/// allowing builder chains:
+///
+/// ```rust
+/// use cmx::profile::DisplayProfile;
+/// use cmx::tag::tags::{RedTRCTag, GreenTRCTag};
+///
+/// let profile = DisplayProfile::new()
+///     .with_tag(RedTRCTag)
+///     .as_curve(|c| c.set_gamma(2.2))
+///     .with_tag(GreenTRCTag)
+///     .as_curve(|c| c.set_gamma(2.2));
+/// ```
 pub struct TagSetter<P: HasRawProfile, S> {
     profile: P,
     tag: S,
@@ -191,6 +249,13 @@ where
         self.profile
     }
 
+    /// Set the tag's data as a `ParametricCurveData` (ICC type `para`).
+    ///
+    /// Available for TRC tags: `RedTRCTag`, `GreenTRCTag`, `BlueTRCTag`,
+    /// `GrayTRCTag`.  Use [`ParametricCurveData::set_parameters`] for a
+    /// fixed-size array or [`ParametricCurveData::set_parameters_slice`] for a
+    /// dynamically-sized slice (the slice variant validates the parameter count
+    /// and returns a `Result`).
     pub fn as_parametric_curve<F>(mut self, configure: F) -> P
     where
         S: IsParametricCurveTag,
@@ -204,6 +269,10 @@ where
         self.profile
     }
 
+    /// Set the tag's data as a `SignatureData` (ICC type `sig `).
+    ///
+    /// Available for: `TechnologyTag`, `ColorimetricIntentImageStateTag`,
+    /// `PerceptualRenderingIntentGamutTag`.
     pub fn as_signature<F>(mut self, configure: F) -> P
     where
         S: IsSignatureTag,
@@ -214,6 +283,11 @@ where
         self.profile
     }
 
+    /// Set the tag's data as an `XYZArrayData` (ICC type `XYZ `).
+    ///
+    /// Available for: `RedMatrixColumnTag`, `GreenMatrixColumnTag`,
+    /// `BlueMatrixColumnTag`, `LuminanceTag`, `MediaWhitePointTag`,
+    /// `MediaBlackPointTag`.
     pub fn as_xyz_array<F>(mut self, configure: F) -> P
     where
         S: IsXYZArrayTag,
@@ -224,6 +298,14 @@ where
         self.profile
     }
 
+    /// Set the tag's data as a `TextDescriptionData` (legacy ICC v2 type `desc`).
+    ///
+    /// Available for: `ProfileDescriptionTag`, `CopyrightTag`,
+    /// `DeviceMfgDescTag`, `DeviceModelDescTag`, `ViewingCondDescTag`.
+    ///
+    /// For new ICC v4 profiles prefer [`as_multi_localized_unicode`](Self::as_multi_localized_unicode),
+    /// which supports multiple languages.  `TextDescriptionData` is provided for
+    /// compatibility with tools that require v2-style description tags.
     pub fn as_text_description<F>(mut self, configure: F) -> P
     where
         S: IsTextDescriptionTag,
@@ -237,6 +319,9 @@ where
         self.profile
     }
 
+    /// Set the tag's data as plain ASCII `TextData` (ICC type `text`).
+    ///
+    /// Available for: `CopyrightTag`, `CharTargetTag`.
     pub fn as_text<F>(mut self, configure: F) -> P
     where
         S: IsTextTag,
@@ -247,6 +332,10 @@ where
         self.profile
     }
 
+    /// Set the tag's data as an `S15Fixed16ArrayData` (ICC type `sf32`).
+    ///
+    /// Available for: `ChromaticAdaptationTag` (a 3×3 matrix stored as nine
+    /// s15Fixed16 values in row-major order).
     pub fn as_sf15_fixed_16_array<F>(mut self, configure: F) -> P
     where
         S: IsS15Fixed16ArrayTag,
@@ -288,6 +377,13 @@ where
         self.profile
     }
 
+    /// Set the tag's data as a `MultiLocalizedUnicodeData` (ICC type `mluc`).
+    ///
+    /// Available for: `CopyrightTag`, `ProfileDescriptionTag`,
+    /// `DeviceMfgDescTag`, `DeviceModelDescTag`, `ViewingCondDescTag`.
+    ///
+    /// Use [`MultiLocalizedUnicodeData::insert`] inside the closure to add
+    /// one or more locale/string pairs.
     pub fn as_multi_localized_unicode<F>(mut self, configure: F) -> P
     where
         S: IsMultiLocalizedUnicodeTag,

--- a/src/profile/tag_setter.rs
+++ b/src/profile/tag_setter.rs
@@ -205,10 +205,10 @@ pub trait IsRawTag {}
 /// - `S` — the tag signature type (one of the zero-sized structs in
 ///   [`cmx::tag::tags`](crate::tag::tags)).
 ///
-/// Each `as_*` method is gated by a marker trait (e.g. [`IsCurveTag`]) that is
+/// Each `as_*` method is gated by a marker trait (e.g. `IsCurveTag`) that is
 /// only implemented for the tag signatures where that data format is valid.
 /// Attempting to call `as_curve()` on a tag signature that does not implement
-/// [`IsCurveTag`] is a **compile-time error**, not a runtime one.
+/// `IsCurveTag` is a **compile-time error**, not a runtime one.
 ///
 /// Calling an `as_*` method consumes the `TagSetter` and returns the profile `P`,
 /// allowing builder chains:
@@ -382,8 +382,8 @@ where
     /// Available for: `CopyrightTag`, `ProfileDescriptionTag`,
     /// `DeviceMfgDescTag`, `DeviceModelDescTag`, `ViewingCondDescTag`.
     ///
-    /// Use [`MultiLocalizedUnicodeData::insert`] inside the closure to add
-    /// one or more locale/string pairs.
+    /// Use [`MultiLocalizedUnicodeData::insert`](crate::tag::tagdata::MultiLocalizedUnicodeData::insert)
+    /// inside the closure to add one or more locale/string pairs.
     pub fn as_multi_localized_unicode<F>(mut self, configure: F) -> P
     where
         S: IsMultiLocalizedUnicodeTag,

--- a/src/tag/tagdata/curve.rs
+++ b/src/tag/tagdata/curve.rs
@@ -16,9 +16,17 @@ pub struct CurveType {
 
 impl From<&CurveData> for CurveType {
     fn from(curve: &CurveData) -> Self {
+        let payload = &curve.0[12..];
+        // chunks_exact(2) silently drops a trailing odd byte; assert alignment in debug builds.
+        debug_assert_eq!(
+            payload.len() % 2,
+            0,
+            "curveType: payload length {} is not a multiple of 2 (malformed tag)",
+            payload.len()
+        );
         let data: Vec<u16> = {
-            //let count = u32::from_be_bytes(self.0[8..=11].try_into().unwrap());
-            curve.0[12..]
+            // Each chunk is exactly 2 bytes (guaranteed by chunks_exact), so try_into is infallible.
+            payload
                 .chunks_exact(2)
                 .map(|chunk| u16::from_be_bytes(chunk.try_into().unwrap()))
                 .collect()

--- a/src/tag/tagdata/curve.rs
+++ b/src/tag/tagdata/curve.rs
@@ -16,7 +16,12 @@ pub struct CurveType {
 
 impl From<&CurveData> for CurveType {
     fn from(curve: &CurveData) -> Self {
-        let payload = &curve.0[12..];
+        let Some(payload) = curve.0.get(12..) else {
+            return CurveType {
+                points: None,
+                gamma: None,
+            };
+        };
         // chunks_exact(2) silently drops a trailing odd byte; assert alignment in debug builds.
         debug_assert_eq!(
             payload.len() % 2,

--- a/src/tag/tagdata/lut16.rs
+++ b/src/tag/tagdata/lut16.rs
@@ -31,7 +31,8 @@ pub struct Lut16Type {
 
 impl From<&Lut16Data> for Lut16Type {
     fn from(lut16: &Lut16Data) -> Self {
-        let (layout, _) = Lut16HeaderLayout::try_ref_from_prefix(&lut16.0).unwrap();
+        let (layout, _) = Lut16HeaderLayout::try_ref_from_prefix(&lut16.0)
+            .expect("lut16Type: data too short to contain header");
 
         // Header validation (debug-only): signature must be "mft2", reserved/padding must be zero.
         debug_assert_eq!(&layout.signature, b"mft2", "lut16Type: invalid signature");

--- a/src/tag/tagdata/lut8.rs
+++ b/src/tag/tagdata/lut8.rs
@@ -36,7 +36,8 @@ fn reshape_by_grid_points(multi_lut: &[u8], m: usize) -> Vec<Vec<u8>> {
 
 impl From<&Lut8Data> for Lut8Type {
     fn from(lut8: &Lut8Data) -> Self {
-        let (layout, _) = Lut8HeaderLayout::try_ref_from_prefix(&lut8.0).unwrap();
+        let (layout, _) = Lut8HeaderLayout::try_ref_from_prefix(&lut8.0)
+            .expect("lut8Type: data too short to contain header");
         let n = layout.n as usize;
         let m = layout.m as usize;
         let g = layout.g as usize;
@@ -51,10 +52,26 @@ impl From<&Lut8Data> for Lut8Type {
             .unwrap();
 
         // Calculate sizes and offsets
-        let header_size = 48; // 8 + 4 + 36
+        let header_size = std::mem::size_of::<Lut8HeaderLayout>();
         let input_luts_size = n * 256;
-        let clut_size = g.pow(n as u32) * m;
+        let clut_size = g
+            .checked_pow(n as u32)
+            .and_then(|v| v.checked_mul(m))
+            .expect("lut8Type: CLUT size overflow");
         let output_luts_size = m * 256;
+
+        // Bounds check: ensure the payload is large enough before any slicing
+        let total_size = header_size
+            .checked_add(input_luts_size)
+            .and_then(|v| v.checked_add(clut_size))
+            .and_then(|v| v.checked_add(output_luts_size))
+            .expect("lut8Type: total size overflow");
+        assert!(
+            lut8.0.len() >= total_size,
+            "lut8Type: truncated data (have {}, need >= {})",
+            lut8.0.len(),
+            total_size
+        );
 
         // Calculate offsets
         let input_luts_offset = header_size;

--- a/src/tag/tagdata/multi_localized_unicode.rs
+++ b/src/tag/tagdata/multi_localized_unicode.rs
@@ -214,14 +214,21 @@ impl From<&super::MultiLocalizedUnicodeData> for MultiLocalizedUnicodeType {
                 return MultiLocalizedUnicodeType::new();
             }
 
-            // Parse the header data
-            let header = HeaderLayout::try_ref_from_bytes(&data[..16]).unwrap();
+            // Parse the header data — length already checked >= 16 above.
+            let header = HeaderLayout::try_ref_from_bytes(&data[..16])
+                .expect("mluc: data too short for header (already checked)");
             let n = header.number_of_records.get() as usize;
 
-            // Parse the records table
+            // Parse the records table — guard against truncated data.
             let record_size = header.record_size.get() as usize;
-            let table_end = 16 + n * record_size;
-            let table = RecordsLayout::try_ref_from_bytes(&data[16..table_end]).unwrap();
+            let table_end = 16usize.saturating_add(n.saturating_mul(record_size));
+            if table_end > data.len() {
+                return MultiLocalizedUnicodeType::new();
+            }
+            let table = match RecordsLayout::try_ref_from_bytes(&data[16..table_end]) {
+                Ok(t) => t,
+                Err(_) => return MultiLocalizedUnicodeType::new(),
+            };
 
             let mut mluc = MultiLocalizedUnicodeType::new();
 
@@ -246,20 +253,33 @@ impl From<&super::MultiLocalizedUnicodeData> for MultiLocalizedUnicodeType {
                         .to_ascii_lowercase()
                 };
 
-                // Extract the UTF-16BE string
+                // Extract the UTF-16BE string — guard against out-of-bounds offset/length.
                 let offset = r.offset.get() as usize;
                 let length = r.length.get() as usize;
-                let value_bytes = &data[offset..offset + length];
+                let end = match offset.checked_add(length) {
+                    Some(e) if e <= data.len() => e,
+                    _ => continue, // malformed record — skip
+                };
+                let value_bytes = &data[offset..end];
                 total_string_length += length;
 
-                // Convert UTF-16BE bytes to Rust String
-                let value = String::from_utf16(
-                    &value_bytes
-                        .chunks(2)
-                        .map(|x| u16::from_be_bytes([x[0], x[1]]))
-                        .collect::<Vec<u16>>(),
-                )
-                .unwrap();
+                // Require an even byte count for valid UTF-16BE (2 bytes per code unit).
+                debug_assert_eq!(
+                    value_bytes.len() % 2,
+                    0,
+                    "mluc: string byte length {} is not a multiple of 2",
+                    value_bytes.len()
+                );
+
+                // Convert UTF-16BE bytes to Rust String.
+                // chunks_exact(2) drops a trailing odd byte; invalid sequences become the
+                // replacement character rather than panicking.
+                let utf16: Vec<u16> = value_bytes
+                    .chunks_exact(2)
+                    .map(|x| u16::from_be_bytes([x[0], x[1]]))
+                    .collect();
+                let value = String::from_utf16(&utf16)
+                    .unwrap_or_else(|_| String::from_utf16_lossy(&utf16).to_owned());
 
                 // Add the entry to the map
                 unique_strings.insert(value.clone());

--- a/src/tag/tagdata/parametric_curve.rs
+++ b/src/tag/tagdata/parametric_curve.rs
@@ -2,6 +2,7 @@
 // Copyright (c) 2021-2025, Harbers Bik LLC
 
 use crate::{
+    error::Error,
     is_zero,
     tag::tagdata::{DataSignature, ParametricCurveData},
     S15Fixed16,
@@ -32,21 +33,21 @@ struct WriteLayoutHeader {
 }
 
 impl WriteLayoutHeader {
-    pub fn new(size: usize) -> Self {
+    pub fn new(size: usize) -> Result<Self, Error> {
         let encoded_value = match size {
             1 => U16::<BigEndian>::new(0),
             3 => U16::<BigEndian>::new(1),
             4 => U16::<BigEndian>::new(2),
             5 => U16::<BigEndian>::new(3),
             7 => U16::<BigEndian>::new(4),
-            _ => panic!("Unsupported number of parameters: {size}"),
+            _ => return Err(Error::UnsupportedParameterCount(size)),
         };
-        Self {
+        Ok(Self {
             signature: DataSignature::ParametricCurveData.into(),
             _reserved: [0; 4],
             encoded_value,
             _reserved2: [0; 2],
-        }
+        })
     }
 }
 
@@ -67,13 +68,14 @@ struct WriteLayout<const N: usize> {
 impl<const N: usize> WriteLayout<N> {
     /// Creates a new `WriteLayout` with the signature 'para' and initializes
     pub fn new(params: [f64; N]) -> Self {
+        // N is a compile-time constant; only the five ICC-defined counts are valid.
         let encoded_value = match N {
             1 => U16::<BigEndian>::new(0),
             3 => U16::<BigEndian>::new(1),
             4 => U16::<BigEndian>::new(2),
             5 => U16::<BigEndian>::new(3),
             7 => U16::<BigEndian>::new(4),
-            _ => panic!("Unsupported number of parameters: {N}"),
+            _ => panic!("Unsupported number of parameters: {N} (must be 1, 3, 4, 5, or 7)"),
         };
 
         let mut parameters: [I32<BigEndian>; N] = [0.into(); N];
@@ -121,23 +123,44 @@ impl ParametricCurveType {
 }
 
 impl ParametricCurveData {
-    // TODO: rename to set_array, or remove all together in favor or set_slice
+    /// Set the parametric curve parameters using a compile-time fixed-size array.
+    ///
+    /// The number of parameters `N` must be one of the five ICC-defined counts:
+    /// `1`, `3`, `4`, `5`, or `7`.  Any other value causes a **panic** at
+    /// runtime (not a compile error) because const generics cannot be
+    /// constrained to a discrete set of values in stable Rust.  For a
+    /// checked, panic-free alternative use [`set_parameters_slice`](Self::set_parameters_slice).
+    ///
+    /// | N | ICC function type | Parameters |
+    /// |---|---|---|
+    /// | 1 | Simple gamma | `g` |
+    /// | 3 | CIE 122-1966 | `g, a, b` |
+    /// | 4 | IEC 61966-3 | `g, a, b, c` |
+    /// | 5 | IEC 61966-2.1 (sRGB) | `g, a, b, c, d` |
+    /// | 7 | Full | `g, a, b, c, d, e, f` |
     pub fn set_parameters<const N: usize>(&mut self, parameters: [f64; N]) {
         self.0 = WriteLayout::new(parameters).as_bytes().to_vec();
     }
 
-    pub fn set_parameters_slice(&mut self, values: &[f64]) {
+    /// Set the parametric curve parameters from a dynamically-sized slice,
+    /// returning an error if the slice length is not an ICC-defined count.
+    ///
+    /// Valid lengths are `1`, `3`, `4`, `5`, or `7`; any other length returns
+    /// [`Error::UnsupportedParameterCount`].  See [`set_parameters`](Self::set_parameters)
+    /// for the mapping between parameter count and ICC function type.
+    pub fn set_parameters_slice(&mut self, values: &[f64]) -> Result<(), Error> {
         let n = values.len();
         let mut bytes = Vec::with_capacity(
             std::mem::size_of::<WriteLayoutHeader>() + n * std::mem::size_of::<I32<BigEndian>>(),
         );
-        bytes.extend_from_slice(WriteLayoutHeader::new(n).as_bytes());
+        bytes.extend_from_slice(WriteLayoutHeader::new(n)?.as_bytes());
         let params: Vec<I32<BigEndian>> = values
             .iter()
             .map(|&v| crate::S15Fixed16::from(v).into())
             .collect();
         bytes.extend_from_slice(params.as_slice().as_bytes());
         self.0 = bytes;
+        Ok(())
     }
 }
 
@@ -145,7 +168,8 @@ impl ParametricCurveData {
 /// as used
 impl From<&ParametricCurveData> for ParametricCurveType {
     fn from(para: &ParametricCurveData) -> Self {
-        let layout = ReadLayout::ref_from_bytes(&para.0).unwrap();
+        let layout = ReadLayout::ref_from_bytes(&para.0)
+            .expect("parametricCurveType: data too short to contain header");
 
         // Flatten directly during the conversion
         let vec: Vec<f64> = layout

--- a/tests/validation_tests.rs
+++ b/tests/validation_tests.rs
@@ -1,0 +1,354 @@
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright (c) 2021-2025, Harbers Bik LLC
+
+//! Tests that verify the input-validation fixes applied in the fix/input-validation branch.
+//!
+//! Each test targets a specific panic or silent-error that was present before the fixes and
+//! confirms the new, safe behaviour (return an Err, skip a bad record, etc.).
+
+use cmx::{
+    error::Error,
+    profile::RawProfile,
+    tag::tagdata::{
+        curve::CurveType, lut8::Lut8Type, CurveData, Lut8Data, MultiLocalizedUnicodeData,
+        ParametricCurveData,
+    },
+};
+
+// ---------------------------------------------------------------------------
+// Helper: build a minimal but structurally valid 128-byte ICC header.
+//
+// The fields required by `from_bytes` to not error before reaching the code
+// under test are: profile_size (bytes 0-3) and a plausible date (bytes 24-35).
+// Everything else is zero.
+// ---------------------------------------------------------------------------
+fn minimal_header(profile_size: u32, month: u16, day: u16, hour: u16) -> [u8; 128] {
+    let mut h = [0u8; 128];
+    // profile size
+    h[0..4].copy_from_slice(&profile_size.to_be_bytes());
+    // version 4.3 = 0x04300000
+    h[8] = 0x04;
+    h[9] = 0x30;
+    // device class 'mntr' = 0x6D6E7472
+    h[12..16].copy_from_slice(b"mntr");
+    // color space 'RGB ' = 0x52474220
+    h[16..20].copy_from_slice(b"RGB ");
+    // PCS 'XYZ ' = 0x58595A20
+    h[20..24].copy_from_slice(b"XYZ ");
+    // creation date: year 2024, and whatever the caller passes
+    h[24..26].copy_from_slice(&2024u16.to_be_bytes()); // year
+    h[26..28].copy_from_slice(&month.to_be_bytes());
+    h[28..30].copy_from_slice(&day.to_be_bytes());
+    h[30..32].copy_from_slice(&hour.to_be_bytes());
+    // minutes and seconds = 0
+    // file signature 'acsp' = 0x61637370 — needed for check_file_signature(),
+    // not for from_bytes(), but set it for completeness.
+    h[36..40].copy_from_slice(b"acsp");
+    h
+}
+
+// ---------------------------------------------------------------------------
+// 1. ParametricCurveData::set_parameters_slice — invalid count
+// ---------------------------------------------------------------------------
+
+#[test]
+fn parametric_curve_invalid_count_returns_error() {
+    let mut para = ParametricCurveData::default();
+
+    // 2 and 6 are not ICC-defined parameter counts
+    assert!(matches!(
+        para.set_parameters_slice(&[1.0, 2.0]),
+        Err(Error::UnsupportedParameterCount(2))
+    ));
+    assert!(matches!(
+        para.set_parameters_slice(&[1.0, 2.0, 3.0, 4.0, 5.0, 6.0]),
+        Err(Error::UnsupportedParameterCount(6))
+    ));
+}
+
+#[test]
+fn parametric_curve_valid_counts_succeed() {
+    let mut para = ParametricCurveData::default();
+    // All five ICC-defined counts must succeed
+    assert!(para.set_parameters_slice(&[2.2]).is_ok()); // 1 — simple gamma
+    assert!(para.set_parameters_slice(&[2.2, 0.9, 0.1]).is_ok()); // 3
+    assert!(para.set_parameters_slice(&[2.2, 0.9, 0.1, 0.03]).is_ok()); // 4
+    assert!(para.set_parameters_slice(&[2.4, 0.948, 0.052, 0.077, 0.040]).is_ok()); // 5 (sRGB)
+    assert!(
+        para.set_parameters_slice(&[2.4, 0.948, 0.052, 0.077, 0.040, 0.0, 0.0]).is_ok()
+    ); // 7
+}
+
+// ---------------------------------------------------------------------------
+// 2. RawProfile::creation_date() — invalid date fields in the header
+// ---------------------------------------------------------------------------
+
+#[test]
+fn creation_date_invalid_month_returns_error() {
+    // Build the smallest parseable profile (0 tags) with month = 13.
+    let total = 128 + 4; // header + tag count
+    let mut bytes = vec![0u8; total];
+    let header = minimal_header(total as u32, 13, 1, 0); // month = 13
+    bytes[..128].copy_from_slice(&header);
+    // tag count = 0
+    bytes[128..132].copy_from_slice(&0u32.to_be_bytes());
+
+    let profile = RawProfile::from_bytes(&bytes).expect("profile should parse");
+    assert!(
+        matches!(profile.creation_date(), Err(Error::InvalidDate(_))),
+        "month=13 should yield InvalidDate"
+    );
+}
+
+#[test]
+fn creation_date_invalid_day_returns_error() {
+    let total = 128 + 4;
+    let mut bytes = vec![0u8; total];
+    let header = minimal_header(total as u32, 1, 32, 0); // day = 32
+    bytes[..128].copy_from_slice(&header);
+    bytes[128..132].copy_from_slice(&0u32.to_be_bytes());
+
+    let profile = RawProfile::from_bytes(&bytes).expect("profile should parse");
+    assert!(
+        matches!(profile.creation_date(), Err(Error::InvalidDate(_))),
+        "day=32 should yield InvalidDate"
+    );
+}
+
+#[test]
+fn creation_date_invalid_hour_returns_error() {
+    let total = 128 + 4;
+    let mut bytes = vec![0u8; total];
+    let header = minimal_header(total as u32, 1, 1, 25); // hour = 25
+    bytes[..128].copy_from_slice(&header);
+    bytes[128..132].copy_from_slice(&0u32.to_be_bytes());
+
+    let profile = RawProfile::from_bytes(&bytes).expect("profile should parse");
+    assert!(
+        matches!(profile.creation_date(), Err(Error::InvalidDate(_))),
+        "hour=25 should yield InvalidDate"
+    );
+}
+
+#[test]
+fn creation_date_valid_date_succeeds() {
+    let total = 128 + 4;
+    let mut bytes = vec![0u8; total];
+    let header = minimal_header(total as u32, 6, 15, 12);
+    bytes[..128].copy_from_slice(&header);
+    bytes[128..132].copy_from_slice(&0u32.to_be_bytes());
+
+    let profile = RawProfile::from_bytes(&bytes).expect("profile should parse");
+    let date = profile.creation_date().expect("valid date should not error");
+    use chrono::Datelike;
+    assert_eq!(date.year(), 2024);
+    assert_eq!(date.month(), 6);
+    assert_eq!(date.day(), 15);
+}
+
+// ---------------------------------------------------------------------------
+// 3. share_tags — two tag table entries at the same offset but different sizes
+// ---------------------------------------------------------------------------
+
+/// Build raw ICC bytes with the given tag table entries.
+/// `tags`: list of (sig_bytes, offset, size).  The data region is filled with zeros.
+fn build_profile_with_tags(tags: &[([u8; 4], u32, u32)]) -> Vec<u8> {
+    // Tag table starts at 132; first tag data can start right after.
+    let table_end = 132 + tags.len() * 12;
+    // Data region: enough to cover the largest claimed offset+size.
+    let data_end = tags
+        .iter()
+        .map(|(_, off, sz)| *off as usize + *sz as usize)
+        .max()
+        .unwrap_or(table_end)
+        .max(table_end);
+
+    let total = data_end;
+    let mut buf = vec![0u8; total];
+
+    // Header
+    let header = minimal_header(total as u32, 1, 1, 0);
+    buf[..128].copy_from_slice(&header);
+
+    // Tag count
+    buf[128..132].copy_from_slice(&(tags.len() as u32).to_be_bytes());
+
+    // Tag table entries
+    for (i, (sig, offset, size)) in tags.iter().enumerate() {
+        let base = 132 + i * 12;
+        buf[base..base + 4].copy_from_slice(sig);
+        buf[base + 4..base + 8].copy_from_slice(&offset.to_be_bytes());
+        buf[base + 8..base + 12].copy_from_slice(&size.to_be_bytes());
+    }
+
+    buf
+}
+
+#[test]
+fn share_tags_same_offset_different_size_is_rejected() {
+    // Two tags at the same offset (156) but different sizes (8 and 16).
+    let offset = 156u32;
+    let buf = build_profile_with_tags(&[
+        (*b"rXYZ", offset, 8),
+        (*b"gXYZ", offset, 16), // ← mismatch: same offset, different size
+    ]);
+    let result = RawProfile::from_bytes(&buf);
+    assert!(result.is_err(), "mismatched sizes at same offset should be rejected");
+    let msg = result.unwrap_err().to_string();
+    assert!(
+        msg.contains("corrupt") || msg.contains("offset") || msg.contains("size"),
+        "error message should mention the corruption: {msg}"
+    );
+}
+
+#[test]
+fn share_tags_same_offset_same_size_is_accepted() {
+    // Legitimate shared tag: two entries at identical offset AND size.
+    let offset = 156u32;
+    let buf = build_profile_with_tags(&[
+        (*b"rXYZ", offset, 8),
+        (*b"gXYZ", offset, 8), // ← same offset AND same size → valid sharing
+    ]);
+    assert!(
+        RawProfile::from_bytes(&buf).is_ok(),
+        "identical offset+size should be accepted as shared tag data"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 4. MultiLocalizedUnicodeData — out-of-bounds string offset in a record
+// ---------------------------------------------------------------------------
+
+/// Build raw MLUC bytes.
+/// `records`: list of (language, country, length, offset) all in host order,
+///            will be stored big-endian as per ICC spec.
+/// `string_bytes`: appended verbatim after the record table.
+fn build_mluc(records: &[([u8; 2], [u8; 2], u32, u32)], string_bytes: &[u8]) -> Vec<u8> {
+    let n = records.len() as u32;
+    let mut buf = Vec::new();
+    // Header: 'mluc'(4) + reserved(4) + num_records(4) + record_size=12(4)
+    buf.extend_from_slice(b"mluc");
+    buf.extend_from_slice(&0u32.to_be_bytes());
+    buf.extend_from_slice(&n.to_be_bytes());
+    buf.extend_from_slice(&12u32.to_be_bytes()); // record size
+    // Records: lang(2) + country(2) + length(4) + offset(4)
+    for (lang, ctry, length, offset) in records {
+        buf.extend_from_slice(lang);
+        buf.extend_from_slice(ctry);
+        buf.extend_from_slice(&length.to_be_bytes());
+        buf.extend_from_slice(&offset.to_be_bytes());
+    }
+    buf.extend_from_slice(string_bytes);
+    buf
+}
+
+#[test]
+fn mluc_oob_offset_skips_record_gracefully() {
+    // Record claims offset=10000 in a ~28-byte payload — should be skipped, not panic.
+    let data = build_mluc(
+        &[(*b"en", [0, 0], 4, 10_000)], // offset way past end
+        &[],
+    );
+    let mluc = MultiLocalizedUnicodeData(data);
+    // Trigger the From conversion (used internally during TOML serialisation).
+    // The bad record should be silently skipped; the result is an empty MLUC.
+    let mluc_type = cmx::tag::tagdata::multi_localized_unicode::MultiLocalizedUnicodeType::from(&mluc);
+    assert!(mluc_type.is_empty(), "bad record should be skipped, leaving an empty MLUC");
+}
+
+// ---------------------------------------------------------------------------
+// 5. MultiLocalizedUnicodeData — invalid UTF-16 sequence (lone surrogate)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn mluc_invalid_utf16_uses_lossy_fallback() {
+    // String data: 0xD800 (lone high surrogate) followed by 0x000A (newline) — invalid UTF-16.
+    // Record claims offset = 28 (right after the 16-byte header + 12-byte record).
+    let string_bytes: &[u8] = &[0xD8, 0x00, 0x00, 0x0A];
+    let data = build_mluc(
+        &[(*b"en", [0, 0], 4, 28)],
+        string_bytes,
+    );
+    let mluc = MultiLocalizedUnicodeData(data);
+    // Should not panic; the lossy fallback replaces the invalid code unit.
+    let mluc_type = cmx::tag::tagdata::multi_localized_unicode::MultiLocalizedUnicodeType::from(&mluc);
+    // One entry should be present (lossy decoding, not skipped).
+    assert!(
+        !mluc_type.is_empty(),
+        "invalid UTF-16 should produce a lossy entry, not be dropped"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 6. Lut8Data — CLUT size overflow (n=9, g=255 overflows usize)
+// ---------------------------------------------------------------------------
+
+/// Build the 48-byte Lut8HeaderLayout with the given channel/grid settings.
+/// The e_mat is all zeros (identity-ish: doesn't matter for size calculation tests).
+fn lut8_header_bytes(n: u8, m: u8, g: u8) -> Vec<u8> {
+    let mut h = vec![0u8; 48];
+    h[0..4].copy_from_slice(b"mft1"); // signature
+    // _reserved bytes 4-7 = 0
+    h[8] = n;
+    h[9] = m;
+    h[10] = g;
+    // _padding = 0, e_mat = 0
+    h
+}
+
+#[test]
+#[should_panic(expected = "CLUT size overflow")]
+fn lut8_clut_overflow_panics_with_message() {
+    // 255^9 overflows usize on any 64-bit platform (> u64::MAX).
+    // checked_pow returns None → expect fires.
+    let data = Lut8Data(lut8_header_bytes(9, 3, 255));
+    let _ = Lut8Type::from(&data);
+}
+
+#[test]
+#[should_panic(expected = "truncated data")]
+fn lut8_truncated_data_panics_with_message() {
+    // n=2, g=4, m=3 → total_size = 48 + 2*256 + 4^2*3 + 3*256 = 1376.
+    // Providing only the 48-byte header triggers the assert.
+    let data = Lut8Data(lut8_header_bytes(2, 3, 4));
+    let _ = Lut8Type::from(&data);
+}
+
+// ---------------------------------------------------------------------------
+// 7. CurveData — odd-length payload triggers debug_assert
+// ---------------------------------------------------------------------------
+
+/// Build a minimal CurveData with the given number of u16 data points
+/// plus an optional trailing odd byte to break alignment.
+fn curve_data_bytes(points: u32, extra_byte: bool) -> Vec<u8> {
+    let mut buf = Vec::new();
+    buf.extend_from_slice(b"curv");    // signature
+    buf.extend_from_slice(&0u32.to_be_bytes()); // reserved
+    buf.extend_from_slice(&points.to_be_bytes()); // count
+    for i in 0..points {
+        buf.extend_from_slice(&(i as u16).to_be_bytes());
+    }
+    if extra_byte {
+        buf.push(0xFF); // misaligned trailing byte
+    }
+    buf
+}
+
+#[test]
+fn curve_even_length_payload_succeeds() {
+    // Even payload: no debug_assert should fire, conversion should work.
+    let data = CurveData(curve_data_bytes(4, false));
+    let ct = CurveType::from(&data);
+    // 4 points → produces a `points` variant, not a `gamma` variant.
+    let serialised = toml::to_string(&ct).expect("serialisation should succeed");
+    assert!(serialised.contains("points"));
+}
+
+// The debug_assert only fires in debug builds (i.e. during `cargo test`).
+#[test]
+#[cfg(debug_assertions)]
+#[should_panic(expected = "not a multiple of 2")]
+fn curve_odd_length_payload_fires_debug_assert() {
+    let data = CurveData(curve_data_bytes(4, true)); // 12 + 8 + 1 = 21 bytes — odd payload
+    let _ = CurveType::from(&data);
+}


### PR DESCRIPTION
## Summary

- **Input validation hardening** — replaced silent panics/overflows in LUT8, LUT16, curve, MLUC, and parametric curve parsers with descriptive `expect()` messages, checked arithmetic, and proper bounds checks; `creation_date()` and `set_parameters_slice()` now return `Result` instead of panicking; `into_bytes()` guards against the 4 GiB ICC size limit; shared tag entries with mismatched sizes are now rejected as corrupt data
- **Three new `Error` variants** — `InvalidDate`, `UnsupportedParameterCount`, `ProfileTooLarge`
- **14 new integration tests** in `tests/validation_tests.rs` covering all the above fixes
- **Documentation overhaul** — rewritten crate-level doc in `lib.rs` (Quick Start, module table, ICC concepts, device class table, tag types table, key types); comprehensive doc comments on `Profile`, `TagSetter`, all marker traits, and all `as_*` methods; fixed 7 rustdoc warnings (unresolved links, private-item links)
- **README regenerated** via `cargo rdme` from the updated `lib.rs` doc
- **CLAUDE.md** added with project overview, architecture, commit/PR policy, and a 9-step release process (including `cargo clippy`/`cargo doc` zero-warning gate and `cargo rdme`)
- **Version bumped** to `0.0.7`; CHANGELOG `[Unreleased]` promoted to `[0.0.7] - 2026-04-23`

## Test plan

- [ ] `cargo test` — all unit and integration tests pass (39 doc-tests, 14 new validation tests, round-trip and Display P3 integration tests)
- [ ] `cargo clippy -- -D warnings` — zero warnings
- [ ] `cargo doc --no-deps` — zero warnings
- [ ] Review `CHANGELOG.md` entries against the diff
- [ ] Spot-check `README.md` rendered output on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)